### PR TITLE
port(upstream#6226): fix(session): skip stop hooks during aborts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded ([#41](https://github.com/santhreal/veyyon/issues/41)).
-
 ## [1.0.37] - 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded ([#41](https://github.com/santhreal/veyyon/issues/41)).
+
 ## [1.0.37] - 2026-07-24
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "veyyon",

--- a/bun.lock
+++ b/bun.lock
@@ -383,6 +383,7 @@
   "overrides": {
     "@ark/schema": "0.56.2",
     "adm-zip": "^0.6.0",
+    "brace-expansion": "5.0.8",
     "tar": "^7.5.20",
   },
   "catalog": {
@@ -1077,7 +1078,7 @@
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 

--- a/docs/internal/ERRATA-GPT5-HARMONY.md
+++ b/docs/internal/ERRATA-GPT5-HARMONY.md
@@ -219,4 +219,4 @@ new piece is (5): when constrained decoding masks the natural collapse
 target, the mass laundered through the un-masked plain-text shadow
 becomes a structurally-invisible exfiltration channel.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/ERRATA-GPT5-HARMONY.md
+++ b/docs/internal/ERRATA-GPT5-HARMONY.md
@@ -219,4 +219,4 @@ new piece is (5): when constrained decoding masks the natural collapse
 target, the mass laundered through the un-masked plain-text shadow
 becomes a structurally-invisible exfiltration channel.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/ERRATA-GPT5-HARMONY.md
+++ b/docs/internal/ERRATA-GPT5-HARMONY.md
@@ -219,4 +219,4 @@ new piece is (5): when constrained decoding masks the natural collapse
 target, the mass laundered through the un-masked plain-text shadow
 becomes a structurally-invisible exfiltration channel.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -143,4 +143,4 @@ Per-model tool-call wire-format notes live in [toolconv/](toolconv/) (Anthropic,
 
 Step-by-step runbooks for when something breaks live in [runbooks/](runbooks/).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -143,4 +143,4 @@ Per-model tool-call wire-format notes live in [toolconv/](toolconv/) (Anthropic,
 
 Step-by-step runbooks for when something breaks live in [runbooks/](runbooks/).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -143,4 +143,4 @@ Per-model tool-call wire-format notes live in [toolconv/](toolconv/) (Anthropic,
 
 Step-by-step runbooks for when something breaks live in [runbooks/](runbooks/).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/adding-a-provider.md
+++ b/docs/internal/adding-a-provider.md
@@ -107,4 +107,4 @@ from the catalog table and `OAuthProvider` from the registry.
   `registerOAuthProvider` (the `AuthStorage.login` dispatcher handles built-ins
   and extensions through the same path).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/adding-a-provider.md
+++ b/docs/internal/adding-a-provider.md
@@ -107,4 +107,4 @@ from the catalog table and `OAuthProvider` from the registry.
   `registerOAuthProvider` (the `AuthStorage.login` dispatcher handles built-ins
   and extensions through the same path).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/adding-a-provider.md
+++ b/docs/internal/adding-a-provider.md
@@ -107,4 +107,4 @@ from the catalog table and `OAuthProvider` from the registry.
   `registerOAuthProvider` (the `AuthStorage.login` dispatcher handles built-ins
   and extensions through the same path).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/agent-workflow.md
+++ b/docs/internal/agent-workflow.md
@@ -121,4 +121,4 @@ a ledger row like any other bug.
   account-level Cloudflare/GitHub state) is a human-blocker: record it in the
   ledger with what was tried, and continue on other rows rather than stopping.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/agent-workflow.md
+++ b/docs/internal/agent-workflow.md
@@ -121,4 +121,4 @@ a ledger row like any other bug.
   account-level Cloudflare/GitHub state) is a human-blocker: record it in the
   ledger with what was tried, and continue on other rows rather than stopping.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/agent-workflow.md
+++ b/docs/internal/agent-workflow.md
@@ -121,4 +121,4 @@ a ledger row like any other bug.
   account-level Cloudflare/GitHub state) is a human-blocker: record it in the
   ledger with what was tried, and continue on other rows rather than stopping.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/ai-schema-normalize.md
+++ b/docs/internal/ai-schema-normalize.md
@@ -184,4 +184,4 @@ and the full merge re-runs.
 - `packages/ai/src/utils/schema/CONSTRAINTS.md`: operational contract for
   every normalization rule.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/ai-schema-normalize.md
+++ b/docs/internal/ai-schema-normalize.md
@@ -184,4 +184,4 @@ and the full merge re-runs.
 - `packages/ai/src/utils/schema/CONSTRAINTS.md`: operational contract for
   every normalization rule.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/ai-schema-normalize.md
+++ b/docs/internal/ai-schema-normalize.md
@@ -184,4 +184,4 @@ and the full merge re-runs.
 - `packages/ai/src/utils/schema/CONSTRAINTS.md`: operational contract for
   every normalization rule.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/arktype-guide.md
+++ b/docs/internal/arktype-guide.md
@@ -131,4 +131,4 @@ is a candidate to **stay on Zod** (external-boundary exception), note it in your
 - Report: files changed, any `.strict`→`"+"`, `.refine`→`.narrow`, `.catch`→morph, and any file you
   intentionally left on Zod (with the reason).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/arktype-guide.md
+++ b/docs/internal/arktype-guide.md
@@ -131,4 +131,4 @@ is a candidate to **stay on Zod** (external-boundary exception), note it in your
 - Report: files changed, any `.strict`→`"+"`, `.refine`→`.narrow`, `.catch`→morph, and any file you
   intentionally left on Zod (with the reason).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/arktype-guide.md
+++ b/docs/internal/arktype-guide.md
@@ -131,4 +131,4 @@ is a candidate to **stay on Zod** (external-boundary exception), note it in your
 - Report: files changed, any `.strict`→`"+"`, `.refine`→`.narrow`, `.catch`→morph, and any file you
   intentionally left on Zod (with the reason).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/auth-broker-gateway.md
+++ b/docs/internal/auth-broker-gateway.md
@@ -197,4 +197,4 @@ The broker only owns OAuth credentials and provider-API-key credentials that wer
 - [`models.md`](../models.md): provider auth resolution order; the broker plugs in at layers 2–3 (stored credentials).
 - [`environment-variables.md`](../environment-variables.md): full env reference including `VEYYON_AUTH_BROKER_URL` / `VEYYON_AUTH_BROKER_TOKEN`.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/auth-broker-gateway.md
+++ b/docs/internal/auth-broker-gateway.md
@@ -197,4 +197,4 @@ The broker only owns OAuth credentials and provider-API-key credentials that wer
 - [`models.md`](../models.md): provider auth resolution order; the broker plugs in at layers 2–3 (stored credentials).
 - [`environment-variables.md`](../environment-variables.md): full env reference including `VEYYON_AUTH_BROKER_URL` / `VEYYON_AUTH_BROKER_TOKEN`.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/auth-broker-gateway.md
+++ b/docs/internal/auth-broker-gateway.md
@@ -197,4 +197,4 @@ The broker only owns OAuth credentials and provider-API-key credentials that wer
 - [`models.md`](../models.md): provider auth resolution order; the broker plugs in at layers 2–3 (stored credentials).
 - [`environment-variables.md`](../environment-variables.md): full env reference including `VEYYON_AUTH_BROKER_URL` / `VEYYON_AUTH_BROKER_TOKEN`.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/bash-tool-runtime.md
+++ b/docs/internal/bash-tool-runtime.md
@@ -286,4 +286,4 @@ This component is wired by `CommandController.handleBashCommand()` and fed from 
 - [`src/modes/rpc/rpc-mode.ts`](../../packages/coding-agent/src/modes/rpc/rpc-mode.ts): RPC `bash` and `abort_bash` command surface.
 - [`src/internal-urls/artifact-protocol.ts`](../../packages/coding-agent/src/internal-urls/artifact-protocol.ts): `artifact://<id>` resolution.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/bash-tool-runtime.md
+++ b/docs/internal/bash-tool-runtime.md
@@ -286,4 +286,4 @@ This component is wired by `CommandController.handleBashCommand()` and fed from 
 - [`src/modes/rpc/rpc-mode.ts`](../../packages/coding-agent/src/modes/rpc/rpc-mode.ts): RPC `bash` and `abort_bash` command surface.
 - [`src/internal-urls/artifact-protocol.ts`](../../packages/coding-agent/src/internal-urls/artifact-protocol.ts): `artifact://<id>` resolution.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/bash-tool-runtime.md
+++ b/docs/internal/bash-tool-runtime.md
@@ -286,4 +286,4 @@ This component is wired by `CommandController.handleBashCommand()` and fed from 
 - [`src/modes/rpc/rpc-mode.ts`](../../packages/coding-agent/src/modes/rpc/rpc-mode.ts): RPC `bash` and `abort_bash` command surface.
 - [`src/internal-urls/artifact-protocol.ts`](../../packages/coding-agent/src/internal-urls/artifact-protocol.ts): `artifact://<id>` resolution.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/blob-artifact-architecture.md
+++ b/docs/internal/blob-artifact-architecture.md
@@ -249,4 +249,4 @@ The two systems intersect only indirectly: both reduce session JSONL bloat, but 
 - [`src/task/output-manager.ts`](../../packages/coding-agent/src/task/output-manager.ts): session-scoped agent output ID allocation for `agent://`.
 - [`src/task/executor.ts`](../../packages/coding-agent/src/task/executor.ts): subagent output artifact writes (`<id>.md`) and session JSONL sidecars.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/blob-artifact-architecture.md
+++ b/docs/internal/blob-artifact-architecture.md
@@ -249,4 +249,4 @@ The two systems intersect only indirectly: both reduce session JSONL bloat, but 
 - [`src/task/output-manager.ts`](../../packages/coding-agent/src/task/output-manager.ts): session-scoped agent output ID allocation for `agent://`.
 - [`src/task/executor.ts`](../../packages/coding-agent/src/task/executor.ts): subagent output artifact writes (`<id>.md`) and session JSONL sidecars.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/blob-artifact-architecture.md
+++ b/docs/internal/blob-artifact-architecture.md
@@ -249,4 +249,4 @@ The two systems intersect only indirectly: both reduce session JSONL bloat, but 
 - [`src/task/output-manager.ts`](../../packages/coding-agent/src/task/output-manager.ts): session-scoped agent output ID allocation for `agent://`.
 - [`src/task/executor.ts`](../../packages/coding-agent/src/task/executor.ts): subagent output artifact writes (`<id>.md`) and session JSONL sidecars.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/brand.md
+++ b/docs/internal/brand.md
@@ -58,4 +58,4 @@ Session welcome is a single hero card (not a dual-column dashboard): wordmark, o
 
 See also: [Themes and identity](../handbook/src/using/themes.md), [TUI design language](./tui-design-language.md).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/brand.md
+++ b/docs/internal/brand.md
@@ -58,4 +58,4 @@ Session welcome is a single hero card (not a dual-column dashboard): wordmark, o
 
 See also: [Themes and identity](../handbook/src/using/themes.md), [TUI design language](./tui-design-language.md).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/brand.md
+++ b/docs/internal/brand.md
@@ -58,4 +58,4 @@ Session welcome is a single hero card (not a dual-column dashboard): wordmark, o
 
 See also: [Themes and identity](../handbook/src/using/themes.md), [TUI design language](./tui-design-language.md).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/deployment.md
+++ b/docs/internal/deployment.md
@@ -199,4 +199,4 @@ edits between releases:
 4. `bun run site:deploy`.
 5. If `install.sh`/`install.ps1` changed, also deploy `veyyon-get`.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/deployment.md
+++ b/docs/internal/deployment.md
@@ -199,4 +199,4 @@ edits between releases:
 4. `bun run site:deploy`.
 5. If `install.sh`/`install.ps1` changed, also deploy `veyyon-get`.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/deployment.md
+++ b/docs/internal/deployment.md
@@ -199,4 +199,4 @@ edits between releases:
 4. `bun run site:deploy`.
 5. If `install.sh`/`install.ps1` changed, also deploy `veyyon-get`.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/extension-loading.md
+++ b/docs/internal/extension-loading.md
@@ -270,4 +270,4 @@ Legacy manifest key still accepted:
 }
 ```
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/extension-loading.md
+++ b/docs/internal/extension-loading.md
@@ -270,4 +270,4 @@ Legacy manifest key still accepted:
 }
 ```
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/extension-loading.md
+++ b/docs/internal/extension-loading.md
@@ -270,4 +270,4 @@ Legacy manifest key still accepted:
 }
 ```
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/fs-scan-cache-architecture.md
+++ b/docs/internal/fs-scan-cache-architecture.md
@@ -188,4 +188,4 @@ When introducing cache use in a new scanner/search path:
 - `glob`/`fuzzyFind`/`astGrep` share scan entries only when the full `WalkOptions` key matches.
 - Every native consumer sets `skip_git=true`, so `.git` is excluded from all cached scans in practice; `should_skip_path` re-enforces it at the discovery-filter layer.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/fs-scan-cache-architecture.md
+++ b/docs/internal/fs-scan-cache-architecture.md
@@ -188,4 +188,4 @@ When introducing cache use in a new scanner/search path:
 - `glob`/`fuzzyFind`/`astGrep` share scan entries only when the full `WalkOptions` key matches.
 - Every native consumer sets `skip_git=true`, so `.git` is excluded from all cached scans in practice; `should_skip_path` re-enforces it at the discovery-filter layer.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/fs-scan-cache-architecture.md
+++ b/docs/internal/fs-scan-cache-architecture.md
@@ -188,4 +188,4 @@ When introducing cache use in a new scanner/search path:
 - `glob`/`fuzzyFind`/`astGrep` share scan entries only when the full `WalkOptions` key matches.
 - Every native consumer sets `skip_git=true`, so `.git` is excluded from all cached scans in practice; `should_skip_path` re-enforces it at the discovery-filter layer.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/gemini-manifest-extensions.md
+++ b/docs/internal/gemini-manifest-extensions.md
@@ -178,4 +178,4 @@ Practical implication:
 
 This boundary is intentional in current implementation and explains why manifest discovery and executable module loading can diverge.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/gemini-manifest-extensions.md
+++ b/docs/internal/gemini-manifest-extensions.md
@@ -178,4 +178,4 @@ Practical implication:
 
 This boundary is intentional in current implementation and explains why manifest discovery and executable module loading can diverge.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/gemini-manifest-extensions.md
+++ b/docs/internal/gemini-manifest-extensions.md
@@ -178,4 +178,4 @@ Practical implication:
 
 This boundary is intentional in current implementation and explains why manifest discovery and executable module loading can diverge.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/handoff-generation-pipeline.md
+++ b/docs/internal/handoff-generation-pipeline.md
@@ -255,4 +255,4 @@ High-level state flow:
 - Manual handoff has no streaming visibility; a cancellable loader is shown until the UI updates after generation completes.
 - Auto-triggered handoffs can write a timestamped `handoff-*.md` artifact when `compaction.handoffSaveToDisk` is enabled; write failure is logged and does not fail the handoff.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/handoff-generation-pipeline.md
+++ b/docs/internal/handoff-generation-pipeline.md
@@ -255,4 +255,4 @@ High-level state flow:
 - Manual handoff has no streaming visibility; a cancellable loader is shown until the UI updates after generation completes.
 - Auto-triggered handoffs can write a timestamped `handoff-*.md` artifact when `compaction.handoffSaveToDisk` is enabled; write failure is logged and does not fail the handoff.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/handoff-generation-pipeline.md
+++ b/docs/internal/handoff-generation-pipeline.md
@@ -255,4 +255,4 @@ High-level state flow:
 - Manual handoff has no streaming visibility; a cancellable loader is shown until the UI updates after generation completes.
 - Auto-triggered handoffs can write a timestamped `handoff-*.md` artifact when `compaction.handoffSaveToDisk` is enabled; write failure is logged and does not fail the handoff.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/install-id.md
+++ b/docs/internal/install-id.md
@@ -40,4 +40,4 @@ New consumers MUST treat the value as opaque and MUST NOT derive PII from it; th
 - [environment-variables.md](../environment-variables.md): `VEYYON_CONFIG_DIR` controls where `install-id` lives.
 - [config-usage.md](../config-usage.md): broader config-root layout.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/install-id.md
+++ b/docs/internal/install-id.md
@@ -40,4 +40,4 @@ New consumers MUST treat the value as opaque and MUST NOT derive PII from it; th
 - [environment-variables.md](../environment-variables.md): `VEYYON_CONFIG_DIR` controls where `install-id` lives.
 - [config-usage.md](../config-usage.md): broader config-root layout.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/install-id.md
+++ b/docs/internal/install-id.md
@@ -40,4 +40,4 @@ New consumers MUST treat the value as opaque and MUST NOT derive PII from it; th
 - [environment-variables.md](../environment-variables.md): `VEYYON_CONFIG_DIR` controls where `install-id` lives.
 - [config-usage.md](../config-usage.md): broader config-root layout.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/local-tiny-models.md
+++ b/docs/internal/local-tiny-models.md
@@ -152,4 +152,4 @@ wins that task.
   unchanged**.
 - `providers.autoThinkingModel` uses the same shipped local options as `providers.memoryModel`.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/local-tiny-models.md
+++ b/docs/internal/local-tiny-models.md
@@ -152,4 +152,4 @@ wins that task.
   unchanged**.
 - `providers.autoThinkingModel` uses the same shipped local options as `providers.memoryModel`.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/local-tiny-models.md
+++ b/docs/internal/local-tiny-models.md
@@ -152,4 +152,4 @@ wins that task.
   unchanged**.
 - `providers.autoThinkingModel` uses the same shipped local options as `providers.memoryModel`.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/macos-signing-notarization.md
+++ b/docs/internal/macos-signing-notarization.md
@@ -130,4 +130,4 @@ APPLE_API_KEY_ID=… APPLE_API_ISSUER_ID=… APPLE_API_KEY=… \
   bash scripts/ci-macos-sign.sh packages/coding-agent/binaries/veyyon-darwin-arm64
 ```
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/macos-signing-notarization.md
+++ b/docs/internal/macos-signing-notarization.md
@@ -130,4 +130,4 @@ APPLE_API_KEY_ID=… APPLE_API_ISSUER_ID=… APPLE_API_KEY=… \
   bash scripts/ci-macos-sign.sh packages/coding-agent/binaries/veyyon-darwin-arm64
 ```
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/macos-signing-notarization.md
+++ b/docs/internal/macos-signing-notarization.md
@@ -130,4 +130,4 @@ APPLE_API_KEY_ID=… APPLE_API_ISSUER_ID=… APPLE_API_KEY=… \
   bash scripts/ci-macos-sign.sh packages/coding-agent/binaries/veyyon-darwin-arm64
 ```
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/mcp-protocol-transports.md
+++ b/docs/internal/mcp-protocol-transports.md
@@ -282,4 +282,4 @@ If the concern is message shape, id correlation, or MCP method ordering, it belo
 
 If the concern is framing (JSONL vs HTTP/SSE), stream parsing, fetch/spawn lifecycle, timeout clocks, or connection teardown, it belongs to transport implementation.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/mcp-protocol-transports.md
+++ b/docs/internal/mcp-protocol-transports.md
@@ -282,4 +282,4 @@ If the concern is message shape, id correlation, or MCP method ordering, it belo
 
 If the concern is framing (JSONL vs HTTP/SSE), stream parsing, fetch/spawn lifecycle, timeout clocks, or connection teardown, it belongs to transport implementation.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/mcp-protocol-transports.md
+++ b/docs/internal/mcp-protocol-transports.md
@@ -282,4 +282,4 @@ If the concern is message shape, id correlation, or MCP method ordering, it belo
 
 If the concern is framing (JSONL vs HTTP/SSE), stream parsing, fetch/spawn lifecycle, timeout clocks, or connection teardown, it belongs to transport implementation.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/mcp-runtime-lifecycle.md
+++ b/docs/internal/mcp-runtime-lifecycle.md
@@ -224,4 +224,4 @@ In current wiring, explicit teardown is used in MCP command flows (for reload/re
 - [`src/modes/controllers/mcp-command-controller.ts`](../../packages/coding-agent/src/modes/controllers/mcp-command-controller.ts): interactive reload/reconnect flows.
 - [`src/task/executor.ts`](../../packages/coding-agent/src/task/executor.ts): subagent MCP proxying via parent manager connections.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/mcp-runtime-lifecycle.md
+++ b/docs/internal/mcp-runtime-lifecycle.md
@@ -224,4 +224,4 @@ In current wiring, explicit teardown is used in MCP command flows (for reload/re
 - [`src/modes/controllers/mcp-command-controller.ts`](../../packages/coding-agent/src/modes/controllers/mcp-command-controller.ts): interactive reload/reconnect flows.
 - [`src/task/executor.ts`](../../packages/coding-agent/src/task/executor.ts): subagent MCP proxying via parent manager connections.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/mcp-runtime-lifecycle.md
+++ b/docs/internal/mcp-runtime-lifecycle.md
@@ -224,4 +224,4 @@ In current wiring, explicit teardown is used in MCP command flows (for reload/re
 - [`src/modes/controllers/mcp-command-controller.ts`](../../packages/coding-agent/src/modes/controllers/mcp-command-controller.ts): interactive reload/reconnect flows.
 - [`src/task/executor.ts`](../../packages/coding-agent/src/task/executor.ts): subagent MCP proxying via parent manager connections.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/mcp-server-tool-authoring.md
+++ b/docs/internal/mcp-server-tool-authoring.md
@@ -229,4 +229,4 @@ For robust MCP authoring in this codebase:
 - [`packages/coding-agent/src/config/resolve-config-value.ts`](../../packages/coding-agent/src/config/resolve-config-value.ts)
 - [`packages/coding-agent/src/mcp/loader.ts`](../../packages/coding-agent/src/mcp/loader.ts)
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/mcp-server-tool-authoring.md
+++ b/docs/internal/mcp-server-tool-authoring.md
@@ -229,4 +229,4 @@ For robust MCP authoring in this codebase:
 - [`packages/coding-agent/src/config/resolve-config-value.ts`](../../packages/coding-agent/src/config/resolve-config-value.ts)
 - [`packages/coding-agent/src/mcp/loader.ts`](../../packages/coding-agent/src/mcp/loader.ts)
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/mcp-server-tool-authoring.md
+++ b/docs/internal/mcp-server-tool-authoring.md
@@ -229,4 +229,4 @@ For robust MCP authoring in this codebase:
 - [`packages/coding-agent/src/config/resolve-config-value.ts`](../../packages/coding-agent/src/config/resolve-config-value.ts)
 - [`packages/coding-agent/src/mcp/loader.ts`](../../packages/coding-agent/src/mcp/loader.ts)
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/mnemosyne-memory-backend.md
+++ b/docs/internal/mnemosyne-memory-backend.md
@@ -162,4 +162,4 @@ new Mnemopi({
 - `/memory stats` and `/memory diagnose` render backend-specific bank statistics/diagnostics when the Mnemopi backend is active.
 - Subagents do not own separate Mnemopi retain loops; they alias the parent state when a parent Mnemopi state exists, and otherwise remain inert.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/mnemosyne-memory-backend.md
+++ b/docs/internal/mnemosyne-memory-backend.md
@@ -162,4 +162,4 @@ new Mnemopi({
 - `/memory stats` and `/memory diagnose` render backend-specific bank statistics/diagnostics when the Mnemopi backend is active.
 - Subagents do not own separate Mnemopi retain loops; they alias the parent state when a parent Mnemopi state exists, and otherwise remain inert.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/mnemosyne-memory-backend.md
+++ b/docs/internal/mnemosyne-memory-backend.md
@@ -162,4 +162,4 @@ new Mnemopi({
 - `/memory stats` and `/memory diagnose` render backend-specific bank statistics/diagnostics when the Mnemopi backend is active.
 - Subagents do not own separate Mnemopi retain loops; they alias the parent state when a parent Mnemopi state exists, and otherwise remain inert.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/native-crates.md
+++ b/docs/internal/native-crates.md
@@ -50,4 +50,4 @@ package (`@veyyon/natives`) and the architecture pages above. Promote a
 crate to a dedicated user-facing doc only when it grows a standalone CLI or
 public API consumed outside `packages/natives`.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/native-crates.md
+++ b/docs/internal/native-crates.md
@@ -50,4 +50,4 @@ package (`@veyyon/natives`) and the architecture pages above. Promote a
 crate to a dedicated user-facing doc only when it grows a standalone CLI or
 public API consumed outside `packages/natives`.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/native-crates.md
+++ b/docs/internal/native-crates.md
@@ -50,4 +50,4 @@ package (`@veyyon/natives`) and the architecture pages above. Promote a
 crate to a dedicated user-facing doc only when it grows a standalone CLI or
 public API consumed outside `packages/natives`.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-addon-loader-runtime.md
+++ b/docs/internal/natives-addon-loader-runtime.md
@@ -202,4 +202,4 @@ Normal package/runtime diagnostics include:
 - local rebuild command (`bun --cwd=packages/natives run build`),
 - optional x64 variant build hint (`TARGET_VARIANT=baseline|modern bun --cwd=packages/natives run build`).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-addon-loader-runtime.md
+++ b/docs/internal/natives-addon-loader-runtime.md
@@ -202,4 +202,4 @@ Normal package/runtime diagnostics include:
 - local rebuild command (`bun --cwd=packages/natives run build`),
 - optional x64 variant build hint (`TARGET_VARIANT=baseline|modern bun --cwd=packages/natives run build`).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-addon-loader-runtime.md
+++ b/docs/internal/natives-addon-loader-runtime.md
@@ -202,4 +202,4 @@ Normal package/runtime diagnostics include:
 - local rebuild command (`bun --cwd=packages/natives run build`),
 - optional x64 variant build hint (`TARGET_VARIANT=baseline|modern bun --cwd=packages/natives run build`).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-architecture.md
+++ b/docs/internal/natives-architecture.md
@@ -171,4 +171,4 @@ For the contributor-facing crate map covering `veyyon-natives`, `veyyon-shell`, 
 - **Compiled binary mode**: Runtime mode where the CLI is bundled and native addons are resolved from embedded/cache paths before package-local paths.
 - **Embedded addon**: Build artifact metadata and archive reference generated into `native/embedded-addon.js` so compiled binaries can extract matching `.node` payloads.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-architecture.md
+++ b/docs/internal/natives-architecture.md
@@ -171,4 +171,4 @@ For the contributor-facing crate map covering `veyyon-natives`, `veyyon-shell`, 
 - **Compiled binary mode**: Runtime mode where the CLI is bundled and native addons are resolved from embedded/cache paths before package-local paths.
 - **Embedded addon**: Build artifact metadata and archive reference generated into `native/embedded-addon.js` so compiled binaries can extract matching `.node` payloads.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-architecture.md
+++ b/docs/internal/natives-architecture.md
@@ -171,4 +171,4 @@ For the contributor-facing crate map covering `veyyon-natives`, `veyyon-shell`, 
 - **Compiled binary mode**: Runtime mode where the CLI is bundled and native addons are resolved from embedded/cache paths before package-local paths.
 - **Embedded addon**: Build artifact metadata and archive reference generated into `native/embedded-addon.js` so compiled binaries can extract matching `.node` payloads.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-binding-contract.md
+++ b/docs/internal/natives-binding-contract.md
@@ -134,4 +134,4 @@ When adding/changing an export, update all of:
 
 Do not add a parallel TS wrapper convention unless the package design intentionally moves back to wrappers; current consumers depend on the direct generated API.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-binding-contract.md
+++ b/docs/internal/natives-binding-contract.md
@@ -134,4 +134,4 @@ When adding/changing an export, update all of:
 
 Do not add a parallel TS wrapper convention unless the package design intentionally moves back to wrappers; current consumers depend on the direct generated API.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-binding-contract.md
+++ b/docs/internal/natives-binding-contract.md
@@ -134,4 +134,4 @@ When adding/changing an export, update all of:
 
 Do not add a parallel TS wrapper convention unless the package design intentionally moves back to wrappers; current consumers depend on the direct generated API.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-build-release-debugging.md
+++ b/docs/internal/natives-build-release-debugging.md
@@ -292,4 +292,4 @@ Workspaces that hardlinked a `.node` before GC retain access via the kernel inod
 
 Trigger an automatic miss by editing any path in the key set: a single touched byte under `crates/`, `Cargo.lock`, `Cargo.toml`, `rust-toolchain.toml`, or `packages/natives/` shifts the tree hash and forces a fresh build at the next populate.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-build-release-debugging.md
+++ b/docs/internal/natives-build-release-debugging.md
@@ -292,4 +292,4 @@ Workspaces that hardlinked a `.node` before GC retain access via the kernel inod
 
 Trigger an automatic miss by editing any path in the key set: a single touched byte under `crates/`, `Cargo.lock`, `Cargo.toml`, `rust-toolchain.toml`, or `packages/natives/` shifts the tree hash and forces a fresh build at the next populate.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-build-release-debugging.md
+++ b/docs/internal/natives-build-release-debugging.md
@@ -292,4 +292,4 @@ Workspaces that hardlinked a `.node` before GC retain access via the kernel inod
 
 Trigger an automatic miss by editing any path in the key set: a single touched byte under `crates/`, `Cargo.lock`, `Cargo.toml`, `rust-toolchain.toml`, or `packages/natives/` shifts the tree hash and forces a fresh build at the next populate.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-media-system-utils.md
+++ b/docs/internal/natives-media-system-utils.md
@@ -157,4 +157,4 @@ Failure transitions:
 - macOS appearance and power helpers intentionally return no-op/null behavior on unsupported platforms.
 - ProjFS is not exposed by this media/system native utility surface. Isolation backend selection, including any ProjFS support, lives in the separate `iso` subsystem.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-media-system-utils.md
+++ b/docs/internal/natives-media-system-utils.md
@@ -157,4 +157,4 @@ Failure transitions:
 - macOS appearance and power helpers intentionally return no-op/null behavior on unsupported platforms.
 - ProjFS is not exposed by this media/system native utility surface. Isolation backend selection, including any ProjFS support, lives in the separate `iso` subsystem.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-media-system-utils.md
+++ b/docs/internal/natives-media-system-utils.md
@@ -157,4 +157,4 @@ Failure transitions:
 - macOS appearance and power helpers intentionally return no-op/null behavior on unsupported platforms.
 - ProjFS is not exposed by this media/system native utility surface. Isolation backend selection, including any ProjFS support, lives in the separate `iso` subsystem.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-rust-task-cancellation.md
+++ b/docs/internal/natives-rust-task-cancellation.md
@@ -216,4 +216,4 @@ Choose one model per API and document it explicitly.
 7. Validate no executor misuse:
    - no long sync work directly inside async futures without `spawn_blocking`/blocking task wrapper.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-rust-task-cancellation.md
+++ b/docs/internal/natives-rust-task-cancellation.md
@@ -216,4 +216,4 @@ Choose one model per API and document it explicitly.
 7. Validate no executor misuse:
    - no long sync work directly inside async futures without `spawn_blocking`/blocking task wrapper.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-rust-task-cancellation.md
+++ b/docs/internal/natives-rust-task-cancellation.md
@@ -216,4 +216,4 @@ Choose one model per API and document it explicitly.
 7. Validate no executor misuse:
    - no long sync work directly inside async futures without `spawn_blocking`/blocking task wrapper.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-shell-pty-process.md
+++ b/docs/internal/natives-shell-pty-process.md
@@ -275,4 +275,4 @@ Layout behavior:
 - **PTY session**: `core` is always cleared after `start()` finishes, including failure paths.
 - **No explicit JS finalizer-driven kill contract** is exposed by wrappers; cleanup is primarily tied to run completion/cancellation paths. Callers should use `timeoutMs`, `AbortSignal`, `shell.abort()`, or `pty.kill()` for deterministic teardown.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/natives-shell-pty-process.md
+++ b/docs/internal/natives-shell-pty-process.md
@@ -275,4 +275,4 @@ Layout behavior:
 - **PTY session**: `core` is always cleared after `start()` finishes, including failure paths.
 - **No explicit JS finalizer-driven kill contract** is exposed by wrappers; cleanup is primarily tied to run completion/cancellation paths. Callers should use `timeoutMs`, `AbortSignal`, `shell.abort()`, or `pty.kill()` for deterministic teardown.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-shell-pty-process.md
+++ b/docs/internal/natives-shell-pty-process.md
@@ -275,4 +275,4 @@ Layout behavior:
 - **PTY session**: `core` is always cleared after `start()` finishes, including failure paths.
 - **No explicit JS finalizer-driven kill contract** is exposed by wrappers; cleanup is primarily tied to run completion/cancellation paths. Callers should use `timeoutMs`, `AbortSignal`, `shell.abort()`, or `pty.kill()` for deterministic teardown.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-text-search-pipeline.md
+++ b/docs/internal/natives-text-search-pipeline.md
@@ -258,4 +258,4 @@ Text functions generally return deterministic transformed output; errors are lim
 5. Rust shapes outputs into N-API objects (`lineNumber`, `matchCount`, `limitReached`, etc.).
 6. Generated bindings return typed JS objects and optional per-match callbacks for `grep`/`glob`.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/natives-text-search-pipeline.md
+++ b/docs/internal/natives-text-search-pipeline.md
@@ -258,4 +258,4 @@ Text functions generally return deterministic transformed output; errors are lim
 5. Rust shapes outputs into N-API objects (`lineNumber`, `matchCount`, `limitReached`, etc.).
 6. Generated bindings return typed JS objects and optional per-match callbacks for `grep`/`glob`.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/natives-text-search-pipeline.md
+++ b/docs/internal/natives-text-search-pipeline.md
@@ -258,4 +258,4 @@ Text functions generally return deterministic transformed output; errors are lim
 5. Rust shapes outputs into N-API objects (`lineNumber`, `matchCount`, `limitReached`, etc.).
 6. Generated bindings return typed JS objects and optional per-match callbacks for `grep`/`glob`.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/non-compaction-retry-policy.md
+++ b/docs/internal/non-compaction-retry-policy.md
@@ -234,4 +234,4 @@ A new retry chain can still start later on a future retryable error after counte
 - `RpcSessionState` currently exposes `autoCompactionEnabled` but not an `autoRetryEnabled` field; RPC callers must track their own toggle state or query settings through other APIs.
 - Model fallback changes append temporary `model_change` entries and may later restore the primary model when its cooldown expires, depending on `retry.fallbackRevertPolicy`.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/non-compaction-retry-policy.md
+++ b/docs/internal/non-compaction-retry-policy.md
@@ -234,4 +234,4 @@ A new retry chain can still start later on a future retryable error after counte
 - `RpcSessionState` currently exposes `autoCompactionEnabled` but not an `autoRetryEnabled` field; RPC callers must track their own toggle state or query settings through other APIs.
 - Model fallback changes append temporary `model_change` entries and may later restore the primary model when its cooldown expires, depending on `retry.fallbackRevertPolicy`.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/non-compaction-retry-policy.md
+++ b/docs/internal/non-compaction-retry-policy.md
@@ -234,4 +234,4 @@ A new retry chain can still start later on a future retryable error after counte
 - `RpcSessionState` currently exposes `autoCompactionEnabled` but not an `autoRetryEnabled` field; RPC callers must track their own toggle state or query settings through other APIs.
 - Model fallback changes append temporary `model_change` entries and may later restore the primary model when its cooldown expires, depending on `retry.fallbackRevertPolicy`.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/notebook-tool-runtime.md
+++ b/docs/internal/notebook-tool-runtime.md
@@ -186,4 +186,4 @@ If a workflow needs both notebook mutation and execution:
 
 Current implementation does not provide a single tool that both mutates `.ipynb` and executes notebook cells through kernel context.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/notebook-tool-runtime.md
+++ b/docs/internal/notebook-tool-runtime.md
@@ -186,4 +186,4 @@ If a workflow needs both notebook mutation and execution:
 
 Current implementation does not provide a single tool that both mutates `.ipynb` and executes notebook cells through kernel context.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/notebook-tool-runtime.md
+++ b/docs/internal/notebook-tool-runtime.md
@@ -186,4 +186,4 @@ If a workflow needs both notebook mutation and execution:
 
 Current implementation does not provide a single tool that both mutates `.ipynb` and executes notebook cells through kernel context.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/onboarding.md
+++ b/docs/internal/onboarding.md
@@ -71,4 +71,4 @@ Open the PR against `main`. Put your change under the affected package's
 fix), and make sure `bun run check` and the tests pass. CI, the security suite, and
 the automated review run before a maintainer reviews it.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/onboarding.md
+++ b/docs/internal/onboarding.md
@@ -71,4 +71,4 @@ Open the PR against `main`. Put your change under the affected package's
 fix), and make sure `bun run check` and the tests pass. CI, the security suite, and
 the automated review run before a maintainer reviews it.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/onboarding.md
+++ b/docs/internal/onboarding.md
@@ -71,4 +71,4 @@ Open the PR against `main`. Put your change under the affected package's
 fix), and make sure `bun run check` and the tests pass. CI, the security suite, and
 the automated review run before a maintainer reviews it.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/plugin-manager-installer-plumbing.md
+++ b/docs/internal/plugin-manager-installer-plumbing.md
@@ -287,4 +287,4 @@ Operationally, `doctor --fix` can repair some drift (`bun install`, orphaned con
 - [`src/extensibility/custom-tools/loader.ts`](../../packages/coding-agent/src/extensibility/custom-tools/loader.ts): runtime wiring for plugin-provided tool modules
 - [`src/extensibility/extensions/loader.ts`](../../packages/coding-agent/src/extensibility/extensions/loader.ts): runtime wiring for plugin-provided extension modules
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/plugin-manager-installer-plumbing.md
+++ b/docs/internal/plugin-manager-installer-plumbing.md
@@ -287,4 +287,4 @@ Operationally, `doctor --fix` can repair some drift (`bun install`, orphaned con
 - [`src/extensibility/custom-tools/loader.ts`](../../packages/coding-agent/src/extensibility/custom-tools/loader.ts): runtime wiring for plugin-provided tool modules
 - [`src/extensibility/extensions/loader.ts`](../../packages/coding-agent/src/extensibility/extensions/loader.ts): runtime wiring for plugin-provided extension modules
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/plugin-manager-installer-plumbing.md
+++ b/docs/internal/plugin-manager-installer-plumbing.md
@@ -287,4 +287,4 @@ Operationally, `doctor --fix` can repair some drift (`bun install`, orphaned con
 - [`src/extensibility/custom-tools/loader.ts`](../../packages/coding-agent/src/extensibility/custom-tools/loader.ts): runtime wiring for plugin-provided tool modules
 - [`src/extensibility/extensions/loader.ts`](../../packages/coding-agent/src/extensibility/extensions/loader.ts): runtime wiring for plugin-provided extension modules
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/porting-from-pi-mono.md
+++ b/docs/internal/porting-from-pi-mono.md
@@ -386,4 +386,4 @@ These exist in our fork but not upstream. **Never overwrite:**
 - Bash interception (`checkBashInterception`)
 - Fuzzy path suggestions in read tool
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/porting-from-pi-mono.md
+++ b/docs/internal/porting-from-pi-mono.md
@@ -386,4 +386,4 @@ These exist in our fork but not upstream. **Never overwrite:**
 - Bash interception (`checkBashInterception`)
 - Fuzzy path suggestions in read tool
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/porting-from-pi-mono.md
+++ b/docs/internal/porting-from-pi-mono.md
@@ -386,4 +386,4 @@ These exist in our fork but not upstream. **Never overwrite:**
 - Bash interception (`checkBashInterception`)
 - Fuzzy path suggestions in read tool
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/porting-to-natives.md
+++ b/docs/internal/porting-to-natives.md
@@ -172,4 +172,4 @@ bench("feature/native", () => {
 - If native is slower, do not switch callsites. Keep or remove the export based on whether it has a near-term owner.
 - If native is faster and behavior-compatible, switch callsites and keep a benchmark to catch regressions.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/porting-to-natives.md
+++ b/docs/internal/porting-to-natives.md
@@ -172,4 +172,4 @@ bench("feature/native", () => {
 - If native is slower, do not switch callsites. Keep or remove the export based on whether it has a near-term owner.
 - If native is faster and behavior-compatible, switch callsites and keep a benchmark to catch regressions.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/porting-to-natives.md
+++ b/docs/internal/porting-to-natives.md
@@ -172,4 +172,4 @@ bench("feature/native", () => {
 - If native is slower, do not switch callsites. Keep or remove the export based on whether it has a near-term owner.
 - If native is faster and behavior-compatible, switch callsites and keep a benchmark to catch regressions.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/provider-endpoint-constraints.md
+++ b/docs/internal/provider-endpoint-constraints.md
@@ -397,4 +397,4 @@ Before adding a branch or compat field, answer these in order:
    tier multipliers, and provider-specific counters such as Copilot
    `premiumRequests`?
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/provider-endpoint-constraints.md
+++ b/docs/internal/provider-endpoint-constraints.md
@@ -397,4 +397,4 @@ Before adding a branch or compat field, answer these in order:
    tier multipliers, and provider-specific counters such as Copilot
    `premiumRequests`?
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/provider-endpoint-constraints.md
+++ b/docs/internal/provider-endpoint-constraints.md
@@ -397,4 +397,4 @@ Before adding a branch or compat field, answer these in order:
    tier multipliers, and provider-specific counters such as Copilot
    `premiumRequests`?
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/provider-streaming-internals.md
+++ b/docs/internal/provider-streaming-internals.md
@@ -217,4 +217,4 @@ Provider-specific (not fully abstracted):
 - [`../../agent/src/agent-loop.ts`](../../packages/agent/src/agent-loop.ts): provider stream consumption and `message_update` bridging.
 - [`../src/session/agent-session.ts`](../../packages/coding-agent/src/session/agent-session.ts): session-level handling of streaming updates, abort, retry, and persistence.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/provider-streaming-internals.md
+++ b/docs/internal/provider-streaming-internals.md
@@ -217,4 +217,4 @@ Provider-specific (not fully abstracted):
 - [`../../agent/src/agent-loop.ts`](../../packages/agent/src/agent-loop.ts): provider stream consumption and `message_update` bridging.
 - [`../src/session/agent-session.ts`](../../packages/coding-agent/src/session/agent-session.ts): session-level handling of streaming updates, abort, retry, and persistence.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/provider-streaming-internals.md
+++ b/docs/internal/provider-streaming-internals.md
@@ -217,4 +217,4 @@ Provider-specific (not fully abstracted):
 - [`../../agent/src/agent-loop.ts`](../../packages/agent/src/agent-loop.ts): provider stream consumption and `message_update` bridging.
 - [`../src/session/agent-session.ts`](../../packages/coding-agent/src/session/agent-session.ts): session-level handling of streaming updates, abort, retry, and persistence.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -116,4 +116,4 @@ ref, or any manual dispatch, get a per-sha, never-cancel concurrency group so a
 later `main` push cannot kill an in-flight release; `scripts/ci-concurrency.test.ts`
 locks that group expression against regressions.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -116,4 +116,4 @@ ref, or any manual dispatch, get a per-sha, never-cancel concurrency group so a
 later `main` push cannot kill an in-flight release; `scripts/ci-concurrency.test.ts`
 locks that group expression against regressions.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -116,4 +116,4 @@ ref, or any manual dispatch, get a per-sha, never-cancel concurrency group so a
 later `main` push cannot kill an in-flight release; `scripts/ci-concurrency.test.ts`
 locks that group expression against regressions.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/resolve-tool-runtime.md
+++ b/docs/internal/resolve-tool-runtime.md
@@ -144,4 +144,4 @@ When `queueResolveHandler(...)` registers a preview, the agent runtime does **no
 - Implement `reject(reason)` when the discard needs cleanup (temp state, locks, notifications); omit it for stateless previews where the default message suffices.
 - If your tool can stage multiple previews, remember they stack as unique-keyed pending invokers (resolved head-first), not a forced tool-choice sequence and not a separate `pushPendingAction` stack.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/resolve-tool-runtime.md
+++ b/docs/internal/resolve-tool-runtime.md
@@ -144,4 +144,4 @@ When `queueResolveHandler(...)` registers a preview, the agent runtime does **no
 - Implement `reject(reason)` when the discard needs cleanup (temp state, locks, notifications); omit it for stateless previews where the default message suffices.
 - If your tool can stage multiple previews, remember they stack as unique-keyed pending invokers (resolved head-first), not a forced tool-choice sequence and not a separate `pushPendingAction` stack.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/resolve-tool-runtime.md
+++ b/docs/internal/resolve-tool-runtime.md
@@ -144,4 +144,4 @@ When `queueResolveHandler(...)` registers a preview, the agent runtime does **no
 - Implement `reject(reason)` when the discard needs cleanup (temp state, locks, notifications); omit it for stateless previews where the default message suffices.
 - If your tool can stage multiple previews, remember they stack as unique-keyed pending invokers (resolved head-first), not a forced tool-choice sequence and not a separate `pushPendingAction` stack.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/retained-patterns.md
+++ b/docs/internal/retained-patterns.md
@@ -79,4 +79,4 @@ the shipped model-slots-plus-3-knob-compaction design (see [Compaction & project
 handoff prompt, preserve behavior. If it touches model-routing *settings knobs*, follow the shipped
 model-slots design above, do not resurrect a role→model matrix because an old fork had one.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/retained-patterns.md
+++ b/docs/internal/retained-patterns.md
@@ -79,4 +79,4 @@ the shipped model-slots-plus-3-knob-compaction design (see [Compaction & project
 handoff prompt, preserve behavior. If it touches model-routing *settings knobs*, follow the shipped
 model-slots design above, do not resurrect a role→model matrix because an old fork had one.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/retained-patterns.md
+++ b/docs/internal/retained-patterns.md
@@ -79,4 +79,4 @@ the shipped model-slots-plus-3-knob-compaction design (see [Compaction & project
 handoff prompt, preserve behavior. If it touches model-routing *settings knobs*, follow the shipped
 model-slots design above, do not resurrect a role→model matrix because an old fork had one.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/rulebook-matching-pipeline.md
+++ b/docs/internal/rulebook-matching-pipeline.md
@@ -266,4 +266,4 @@ Implications:
 3. Rule selection for `rule://` includes rulebook, always-apply, and registered TTSR rules (so a triggered TTSR rule can be re-read), but not rules that registered no condition and carry neither a description nor `alwaysApply`.
 4. Discovery warnings (`loadCapability("rules").warnings`) are produced but `createAgentSession` does not currently surface/log them in this path.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/rulebook-matching-pipeline.md
+++ b/docs/internal/rulebook-matching-pipeline.md
@@ -266,4 +266,4 @@ Implications:
 3. Rule selection for `rule://` includes rulebook, always-apply, and registered TTSR rules (so a triggered TTSR rule can be re-read), but not rules that registered no condition and carry neither a description nor `alwaysApply`.
 4. Discovery warnings (`loadCapability("rules").warnings`) are produced but `createAgentSession` does not currently surface/log them in this path.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/rulebook-matching-pipeline.md
+++ b/docs/internal/rulebook-matching-pipeline.md
@@ -266,4 +266,4 @@ Implications:
 3. Rule selection for `rule://` includes rulebook, always-apply, and registered TTSR rules (so a triggered TTSR rule can be re-read), but not rules that registered no condition and carry neither a description nor `alwaysApply`.
 4. Discovery warnings (`loadCapability("rules").warnings`) are produced but `createAgentSession` does not currently surface/log them in this path.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/runbooks/README.md
+++ b/docs/internal/runbooks/README.md
@@ -10,4 +10,4 @@ recovery → verification. For the normal (non-incident) flows, see [releasing](
 | [secret-rotation.md](secret-rotation.md) | Rotating Apple signing secrets, the Cloudflare Pages token, or auth-broker bearer tokens. |
 | [install-rollback.md](install-rollback.md) | A published release is bad and `curl … | sh` is serving it to users. |
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/runbooks/README.md
+++ b/docs/internal/runbooks/README.md
@@ -10,4 +10,4 @@ recovery → verification. For the normal (non-incident) flows, see [releasing](
 | [secret-rotation.md](secret-rotation.md) | Rotating Apple signing secrets, the Cloudflare Pages token, or auth-broker bearer tokens. |
 | [install-rollback.md](install-rollback.md) | A published release is bad and `curl … | sh` is serving it to users. |
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/runbooks/README.md
+++ b/docs/internal/runbooks/README.md
@@ -10,4 +10,4 @@ recovery → verification. For the normal (non-incident) flows, see [releasing](
 | [secret-rotation.md](secret-rotation.md) | Rotating Apple signing secrets, the Cloudflare Pages token, or auth-broker bearer tokens. |
 | [install-rollback.md](install-rollback.md) | A published release is bad and `curl … | sh` is serving it to users. |
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/runbooks/install-rollback.md
+++ b/docs/internal/runbooks/install-rollback.md
@@ -40,4 +40,4 @@ binary back does not lose sessions or config:
 2. Once the new release publishes and verifies, it becomes `latest` automatically.
 3. Only then delete the bad release + tag if you want it gone.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/runbooks/install-rollback.md
+++ b/docs/internal/runbooks/install-rollback.md
@@ -40,4 +40,4 @@ binary back does not lose sessions or config:
 2. Once the new release publishes and verifies, it becomes `latest` automatically.
 3. Only then delete the bad release + tag if you want it gone.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/runbooks/install-rollback.md
+++ b/docs/internal/runbooks/install-rollback.md
@@ -40,4 +40,4 @@ binary back does not lose sessions or config:
 2. Once the new release publishes and verifies, it becomes `latest` automatically.
 3. Only then delete the bad release + tag if you want it gone.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/runbooks/release-recovery.md
+++ b/docs/internal/runbooks/release-recovery.md
@@ -52,4 +52,4 @@ Symptom: `curl -fsSL https://get.veyyon.dev | sh` fails, or fails a checksum.
 2. `veyyon --version` reports the new version.
 3. `veyyon plugin doctor` is green.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/runbooks/release-recovery.md
+++ b/docs/internal/runbooks/release-recovery.md
@@ -52,4 +52,4 @@ Symptom: `curl -fsSL https://get.veyyon.dev | sh` fails, or fails a checksum.
 2. `veyyon --version` reports the new version.
 3. `veyyon plugin doctor` is green.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/runbooks/release-recovery.md
+++ b/docs/internal/runbooks/release-recovery.md
@@ -52,4 +52,4 @@ Symptom: `curl -fsSL https://get.veyyon.dev | sh` fails, or fails a checksum.
 2. `veyyon --version` reports the new version.
 3. `veyyon plugin doctor` is green.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/runbooks/secret-rotation.md
+++ b/docs/internal/runbooks/secret-rotation.md
@@ -52,4 +52,4 @@ The broker and gateway each authenticate every endpoint (except health) with a b
 - Confirm a test run of the affected system works with the new secret **before** revoking the old one.
 - If the rotation was triggered by a leak, also audit access logs for use of the leaked value.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/runbooks/secret-rotation.md
+++ b/docs/internal/runbooks/secret-rotation.md
@@ -52,4 +52,4 @@ The broker and gateway each authenticate every endpoint (except health) with a b
 - Confirm a test run of the affected system works with the new secret **before** revoking the old one.
 - If the rotation was triggered by a leak, also audit access logs for use of the leaked value.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/runbooks/secret-rotation.md
+++ b/docs/internal/runbooks/secret-rotation.md
@@ -52,4 +52,4 @@ The broker and gateway each authenticate every endpoint (except health) with a b
 - Confirm a test run of the affected system works with the new secret **before** revoking the old one.
 - If the rotation was triggered by a leak, also audit access logs for use of the leaked value.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/session-operations-export-share-fork-resume.md
+++ b/docs/internal/session-operations-export-share-fork-resume.md
@@ -332,4 +332,4 @@ When session manager is created with `SessionManager.inMemory()` (`--no-session`
 - `/share` custom-share failures do not degrade to the default encrypted share flow; they terminate the command with error.
 - `/export` argument tokenization is simplistic and does not preserve quoted paths with spaces.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/session-operations-export-share-fork-resume.md
+++ b/docs/internal/session-operations-export-share-fork-resume.md
@@ -332,4 +332,4 @@ When session manager is created with `SessionManager.inMemory()` (`--no-session`
 - `/share` custom-share failures do not degrade to the default encrypted share flow; they terminate the command with error.
 - `/export` argument tokenization is simplistic and does not preserve quoted paths with spaces.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/session-operations-export-share-fork-resume.md
+++ b/docs/internal/session-operations-export-share-fork-resume.md
@@ -332,4 +332,4 @@ When session manager is created with `SessionManager.inMemory()` (`--no-session`
 - `/share` custom-share failures do not degrade to the default encrypted share flow; they terminate the command with error.
 - `/export` argument tokenization is simplistic and does not preserve quoted paths with spaces.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/session-switching-and-recent-listing.md
+++ b/docs/internal/session-switching-and-recent-listing.md
@@ -248,4 +248,4 @@ Switch/open can still throw on true I/O failures (permission errors, rewrite fai
 - First match in modified-descending order wins; there is no ambiguity UI if multiple sessions share a prefix.
 - Prefix-listing metadata is intentionally lightweight, so search text may not include messages outside the first 4KB of the session file.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/session-switching-and-recent-listing.md
+++ b/docs/internal/session-switching-and-recent-listing.md
@@ -248,4 +248,4 @@ Switch/open can still throw on true I/O failures (permission errors, rewrite fai
 - First match in modified-descending order wins; there is no ambiguity UI if multiple sessions share a prefix.
 - Prefix-listing metadata is intentionally lightweight, so search text may not include messages outside the first 4KB of the session file.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/session-switching-and-recent-listing.md
+++ b/docs/internal/session-switching-and-recent-listing.md
@@ -248,4 +248,4 @@ Switch/open can still throw on true I/O failures (permission errors, rewrite fai
 - First match in modified-descending order wins; there is no ambiguity UI if multiple sessions share a prefix.
 - Prefix-listing metadata is intentionally lightweight, so search text may not include messages outside the first 4KB of the session file.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/session-tree-plan.md
+++ b/docs/internal/session-tree-plan.md
@@ -222,4 +222,4 @@ Session migrations still run on load:
 
 Current runtime behavior is version-3 tree semantics after migration.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/session-tree-plan.md
+++ b/docs/internal/session-tree-plan.md
@@ -222,4 +222,4 @@ Session migrations still run on load:
 
 Current runtime behavior is version-3 tree semantics after migration.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/session-tree-plan.md
+++ b/docs/internal/session-tree-plan.md
@@ -222,4 +222,4 @@ Session migrations still run on load:
 
 Current runtime behavior is version-3 tree semantics after migration.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/session.md
+++ b/docs/internal/session.md
@@ -761,4 +761,4 @@ Metadata extraction for `getRecentSessions` reads a prefix via `readTextSlices(.
 
 Use session files for conversation graph/state replay; use `HistoryStorage` for prompt history UX.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/session.md
+++ b/docs/internal/session.md
@@ -761,4 +761,4 @@ Metadata extraction for `getRecentSessions` reads a prefix via `readTextSlices(.
 
 Use session files for conversation graph/state replay; use `HistoryStorage` for prompt history UX.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/session.md
+++ b/docs/internal/session.md
@@ -761,4 +761,4 @@ Metadata extraction for `getRecentSessions` reads a prefix via `readTextSlices(.
 
 Use session files for conversation graph/state replay; use `HistoryStorage` for prompt history UX.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/slash-command-internals.md
+++ b/docs/internal/slash-command-internals.md
@@ -244,4 +244,4 @@ Interactive mode separately hard-handles many built-ins in `InputController` (fo
   - non-native commands: warning + fallback key/value parse
 - Extension/custom command handler exceptions are caught and reported via extension error channel (or logger fallback for custom commands without extension runner), and treated as handled (no unintended fallback execution).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/slash-command-internals.md
+++ b/docs/internal/slash-command-internals.md
@@ -244,4 +244,4 @@ Interactive mode separately hard-handles many built-ins in `InputController` (fo
   - non-native commands: warning + fallback key/value parse
 - Extension/custom command handler exceptions are caught and reported via extension error channel (or logger fallback for custom commands without extension runner), and treated as handled (no unintended fallback execution).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/slash-command-internals.md
+++ b/docs/internal/slash-command-internals.md
@@ -244,4 +244,4 @@ Interactive mode separately hard-handles many built-ins in `InputController` (fo
   - non-native commands: warning + fallback key/value parse
 - Extension/custom command handler exceptions are caught and reported via extension error channel (or logger fallback for custom commands without extension runner), and treated as handled (no unintended fallback execution).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/task-agent-discovery.md
+++ b/docs/internal/task-agent-discovery.md
@@ -189,4 +189,4 @@ When parent plan mode is enabled, `TaskTool.#runSpawn` builds an `effectiveAgent
 
 The same `effectiveAgent` is used for subprocess launch, model/thinking overrides, and output-schema selection.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/task-agent-discovery.md
+++ b/docs/internal/task-agent-discovery.md
@@ -189,4 +189,4 @@ When parent plan mode is enabled, `TaskTool.#runSpawn` builds an `effectiveAgent
 
 The same `effectiveAgent` is used for subprocess launch, model/thinking overrides, and output-schema selection.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/task-agent-discovery.md
+++ b/docs/internal/task-agent-discovery.md
@@ -189,4 +189,4 @@ When parent plan mode is enabled, `TaskTool.#runSpawn` builds an `effectiveAgent
 
 The same `effectiveAgent` is used for subprocess launch, model/thinking overrides, and output-schema selection.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/anthropic.md
+++ b/docs/internal/toolconv/anthropic.md
@@ -629,4 +629,4 @@ Legacy notes: no built-in tools (everything is prompt-defined); Anthropic recomm
 - Messages API reference (`stop_reason` enum, response shape, `tools`): https://docs.claude.com/en/api/messages
 - Legacy tool use (archived; verbatim XML tags and prompt): https://web.archive.org/web/20240528231249/https://docs.anthropic.com/en/docs/legacy-tool-use ; also live localized copies, e.g. https://docs.anthropic.com/de/docs/legacy-tool-use (English path now redirects to the tool-use overview)
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/anthropic.md
+++ b/docs/internal/toolconv/anthropic.md
@@ -629,4 +629,4 @@ Legacy notes: no built-in tools (everything is prompt-defined); Anthropic recomm
 - Messages API reference (`stop_reason` enum, response shape, `tools`): https://docs.claude.com/en/api/messages
 - Legacy tool use (archived; verbatim XML tags and prompt): https://web.archive.org/web/20240528231249/https://docs.anthropic.com/en/docs/legacy-tool-use ; also live localized copies, e.g. https://docs.anthropic.com/de/docs/legacy-tool-use (English path now redirects to the tool-use overview)
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/anthropic.md
+++ b/docs/internal/toolconv/anthropic.md
@@ -629,4 +629,4 @@ Legacy notes: no built-in tools (everything is prompt-defined); Anthropic recomm
 - Messages API reference (`stop_reason` enum, response shape, `tools`): https://docs.claude.com/en/api/messages
 - Legacy tool use (archived; verbatim XML tags and prompt): https://web.archive.org/web/20240528231249/https://docs.anthropic.com/en/docs/legacy-tool-use ; also live localized copies, e.g. https://docs.anthropic.com/de/docs/legacy-tool-use (English path now redirects to the tool-use overview)
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/deepseek.md
+++ b/docs/internal/toolconv/deepseek.md
@@ -382,4 +382,4 @@ reuse the same fullwidth pipe (`｜`, U+FF5C), but the body is an Anthropic-styl
 - vLLM Tool Calling docs (`deepseek_v3`, `deepseek_v31` parser flags): <https://docs.vllm.ai/en/latest/features/tool_calling/>
 - vLLM Reasoning Outputs docs (`deepseek_r1` reasoning parser; V3.1 thinking default): <https://docs.vllm.ai/en/latest/features/reasoning_outputs/>
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/deepseek.md
+++ b/docs/internal/toolconv/deepseek.md
@@ -382,4 +382,4 @@ reuse the same fullwidth pipe (`｜`, U+FF5C), but the body is an Anthropic-styl
 - vLLM Tool Calling docs (`deepseek_v3`, `deepseek_v31` parser flags): <https://docs.vllm.ai/en/latest/features/tool_calling/>
 - vLLM Reasoning Outputs docs (`deepseek_r1` reasoning parser; V3.1 thinking default): <https://docs.vllm.ai/en/latest/features/reasoning_outputs/>
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/deepseek.md
+++ b/docs/internal/toolconv/deepseek.md
@@ -382,4 +382,4 @@ reuse the same fullwidth pipe (`｜`, U+FF5C), but the body is an Anthropic-styl
 - vLLM Tool Calling docs (`deepseek_v3`, `deepseek_v31` parser flags): <https://docs.vllm.ai/en/latest/features/tool_calling/>
 - vLLM Reasoning Outputs docs (`deepseek_r1` reasoning parser; V3.1 thinking default): <https://docs.vllm.ai/en/latest/features/reasoning_outputs/>
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/gemini.md
+++ b/docs/internal/toolconv/gemini.md
@@ -146,4 +146,4 @@ It's currently 11.4°C in London.
 - Gemini 3 thought signatures + functionCall ids: https://ai.google.dev/gemini-api/docs/gemini-3
 - `default_api` / `tool_code` leak evidence: https://github.com/google/adk-go/issues/492 · https://github.com/google-gemini/cookbook/issues/929 · https://github.com/firebase/genkit/issues/2628 · https://discuss.ai.google.dev/t/gemini-2-flash-api-returns-raw-markdown-instead-of-function-call/71964
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/gemini.md
+++ b/docs/internal/toolconv/gemini.md
@@ -146,4 +146,4 @@ It's currently 11.4°C in London.
 - Gemini 3 thought signatures + functionCall ids: https://ai.google.dev/gemini-api/docs/gemini-3
 - `default_api` / `tool_code` leak evidence: https://github.com/google/adk-go/issues/492 · https://github.com/google-gemini/cookbook/issues/929 · https://github.com/firebase/genkit/issues/2628 · https://discuss.ai.google.dev/t/gemini-2-flash-api-returns-raw-markdown-instead-of-function-call/71964
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/gemini.md
+++ b/docs/internal/toolconv/gemini.md
@@ -146,4 +146,4 @@ It's currently 11.4°C in London.
 - Gemini 3 thought signatures + functionCall ids: https://ai.google.dev/gemini-api/docs/gemini-3
 - `default_api` / `tool_code` leak evidence: https://github.com/google/adk-go/issues/492 · https://github.com/google-gemini/cookbook/issues/929 · https://github.com/firebase/genkit/issues/2628 · https://discuss.ai.google.dev/t/gemini-2-flash-api-returns-raw-markdown-instead-of-function-call/71964
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/gemma.md
+++ b/docs/internal/toolconv/gemma.md
@@ -102,4 +102,4 @@ The current weather in Tokyo is 15 degrees Celsius and sunny.<turn|>
 - Function calling with Gemma 4: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4
 - Gemma 4 prompt formatting: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/gemma.md
+++ b/docs/internal/toolconv/gemma.md
@@ -102,4 +102,4 @@ The current weather in Tokyo is 15 degrees Celsius and sunny.<turn|>
 - Function calling with Gemma 4: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4
 - Gemma 4 prompt formatting: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/gemma.md
+++ b/docs/internal/toolconv/gemma.md
@@ -102,4 +102,4 @@ The current weather in Tokyo is 15 degrees Celsius and sunny.<turn|>
 - Function calling with Gemma 4: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4
 - Gemma 4 prompt formatting: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/glm-4.5.md
+++ b/docs/internal/toolconv/glm-4.5.md
@@ -295,4 +295,4 @@ With a server parser active (`--tool-call-parser glm45 --reasoning-parser glm45`
 - SGLang GLM-4.7 detector (`Glm47MoeDetector`: newline-less / back-to-back calls): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/function_call/glm47_moe_detector.py
 - vLLM tool-calling docs: https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/glm-4.5.md
+++ b/docs/internal/toolconv/glm-4.5.md
@@ -295,4 +295,4 @@ With a server parser active (`--tool-call-parser glm45 --reasoning-parser glm45`
 - SGLang GLM-4.7 detector (`Glm47MoeDetector`: newline-less / back-to-back calls): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/function_call/glm47_moe_detector.py
 - vLLM tool-calling docs: https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/glm-4.5.md
+++ b/docs/internal/toolconv/glm-4.5.md
@@ -295,4 +295,4 @@ With a server parser active (`--tool-call-parser glm45 --reasoning-parser glm45`
 - SGLang GLM-4.7 detector (`Glm47MoeDetector`: newline-less / back-to-back calls): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/function_call/glm47_moe_detector.py
 - vLLM tool-calling docs: https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/harmony.md
+++ b/docs/internal/toolconv/harmony.md
@@ -223,4 +223,4 @@ When a server (vLLM/SGLang/Ollama) bridges Harmony to Chat Completions JSON:
 - vLLM tool calling / gpt-oss parser flags: https://docs.vllm.ai/en/latest/features/tool_calling/
 - SGLang gpt-oss usage (`--tool-call-parser gpt-oss`): https://docs.sglang.io/basic_usage/gpt_oss.html
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/harmony.md
+++ b/docs/internal/toolconv/harmony.md
@@ -223,4 +223,4 @@ When a server (vLLM/SGLang/Ollama) bridges Harmony to Chat Completions JSON:
 - vLLM tool calling / gpt-oss parser flags: https://docs.vllm.ai/en/latest/features/tool_calling/
 - SGLang gpt-oss usage (`--tool-call-parser gpt-oss`): https://docs.sglang.io/basic_usage/gpt_oss.html
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/harmony.md
+++ b/docs/internal/toolconv/harmony.md
@@ -223,4 +223,4 @@ When a server (vLLM/SGLang/Ollama) bridges Harmony to Chat Completions JSON:
 - vLLM tool calling / gpt-oss parser flags: https://docs.vllm.ai/en/latest/features/tool_calling/
 - SGLang gpt-oss usage (`--tool-call-parser gpt-oss`): https://docs.sglang.io/basic_usage/gpt_oss.html
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/kimi-k2.md
+++ b/docs/internal/toolconv/kimi-k2.md
@@ -181,4 +181,4 @@ Moonshot's hosted API (`platform.moonshot.ai`) exposes both OpenAI- and Anthropi
 - vLLM PR adding the parser: https://github.com/vllm-project/vllm/pull/20789
 - vLLM tool-calling docs: https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/kimi-k2.md
+++ b/docs/internal/toolconv/kimi-k2.md
@@ -181,4 +181,4 @@ Moonshot's hosted API (`platform.moonshot.ai`) exposes both OpenAI- and Anthropi
 - vLLM PR adding the parser: https://github.com/vllm-project/vllm/pull/20789
 - vLLM tool-calling docs: https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/kimi-k2.md
+++ b/docs/internal/toolconv/kimi-k2.md
@@ -181,4 +181,4 @@ Moonshot's hosted API (`platform.moonshot.ai`) exposes both OpenAI- and Anthropi
 - vLLM PR adding the parser: https://github.com/vllm-project/vllm/pull/20789
 - vLLM tool-calling docs: https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/pi-native.md
+++ b/docs/internal/toolconv/pi-native.md
@@ -275,4 +275,4 @@ pi-native is specified here; it is not derived from a published model template. 
 - Anthropic attribute XML (`<invoke name="…">` / `<parameter name="…">`, "parsed with regular expressions", not required to be valid XML): [`anthropic.md`](./anthropic.md).
 - GLM-4.5 schema-driven, **unquoted** string values vs JSON non-strings, and positional (id-less) call↔result correlation: [`glm-4.5.md`](./glm-4.5.md).
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/pi-native.md
+++ b/docs/internal/toolconv/pi-native.md
@@ -275,4 +275,4 @@ pi-native is specified here; it is not derived from a published model template. 
 - Anthropic attribute XML (`<invoke name="…">` / `<parameter name="…">`, "parsed with regular expressions", not required to be valid XML): [`anthropic.md`](./anthropic.md).
 - GLM-4.5 schema-driven, **unquoted** string values vs JSON non-strings, and positional (id-less) call↔result correlation: [`glm-4.5.md`](./glm-4.5.md).
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/pi-native.md
+++ b/docs/internal/toolconv/pi-native.md
@@ -275,4 +275,4 @@ pi-native is specified here; it is not derived from a published model template. 
 - Anthropic attribute XML (`<invoke name="…">` / `<parameter name="…">`, "parsed with regular expressions", not required to be valid XML): [`anthropic.md`](./anthropic.md).
 - GLM-4.5 schema-driven, **unquoted** string values vs JSON non-strings, and positional (id-less) call↔result correlation: [`glm-4.5.md`](./glm-4.5.md).
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/toolconv/qwen3.md
+++ b/docs/internal/toolconv/qwen3.md
@@ -205,4 +205,4 @@ message.tool_calls = [
 - NousResearch Hermes-Function-Calling (origin of the convention): https://github.com/NousResearch/Hermes-Function-Calling
 - vLLM tool-calling docs (`hermes` parser, Qwen models, auto tool choice): https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/toolconv/qwen3.md
+++ b/docs/internal/toolconv/qwen3.md
@@ -205,4 +205,4 @@ message.tool_calls = [
 - NousResearch Hermes-Function-Calling (origin of the convention): https://github.com/NousResearch/Hermes-Function-Calling
 - vLLM tool-calling docs (`hermes` parser, Qwen models, auto tool choice): https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/toolconv/qwen3.md
+++ b/docs/internal/toolconv/qwen3.md
@@ -205,4 +205,4 @@ message.tool_calls = [
 - NousResearch Hermes-Function-Calling (origin of the convention): https://github.com/NousResearch/Hermes-Function-Calling
 - vLLM tool-calling docs (`hermes` parser, Qwen models, auto tool choice): https://docs.vllm.ai/en/latest/features/tool_calling/
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/ttsr-injection-lifecycle.md
+++ b/docs/internal/ttsr-injection-lifecycle.md
@@ -237,4 +237,4 @@ During the timer window, state can change (user interruption, mode actions, addi
 - Tool-source non-interrupting buckets are cleared when the parent assistant message ends with `stopReason === "aborted"` or `"error"`, so rules whose target tool never produced a result remain eligible to re-trigger.
 - Repeat-after-gap depends on turn count increments at `turn_end`; mid-turn chunks do not advance gap counters.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/ttsr-injection-lifecycle.md
+++ b/docs/internal/ttsr-injection-lifecycle.md
@@ -237,4 +237,4 @@ During the timer window, state can change (user interruption, mode actions, addi
 - Tool-source non-interrupting buckets are cleared when the parent assistant message ends with `stopReason === "aborted"` or `"error"`, so rules whose target tool never produced a result remain eligible to re-trigger.
 - Repeat-after-gap depends on turn count increments at `turn_end`; mid-turn chunks do not advance gap counters.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/ttsr-injection-lifecycle.md
+++ b/docs/internal/ttsr-injection-lifecycle.md
@@ -237,4 +237,4 @@ During the timer window, state can change (user interruption, mode actions, addi
 - Tool-source non-interrupting buckets are cleared when the parent assistant message ends with `stopReason === "aborted"` or `"error"`, so rules whose target tool never produced a result remain eligible to re-trigger.
 - Repeat-after-gap depends on turn count increments at `turn_end`; mid-turn chunks do not advance gap counters.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/tui-core-renderer.md
+++ b/docs/internal/tui-core-renderer.md
@@ -397,4 +397,4 @@ bottom.
   Shift+drag (the standard convention in mouse-capturing TUIs). The setting
   documents this and can be switched off to return to native scrollback.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/tui-core-renderer.md
+++ b/docs/internal/tui-core-renderer.md
@@ -397,4 +397,4 @@ bottom.
   Shift+drag (the standard convention in mouse-capturing TUIs). The setting
   documents this and can be switched off to return to native scrollback.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/tui-core-renderer.md
+++ b/docs/internal/tui-core-renderer.md
@@ -397,4 +397,4 @@ bottom.
   Shift+drag (the standard convention in mouse-capturing TUIs). The setting
   documents this and can be switched off to return to native scrollback.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/tui-runtime-internals.md
+++ b/docs/internal/tui-runtime-internals.md
@@ -227,4 +227,4 @@ Throttled/debounced paths:
 
 The runtime therefore mixes event-driven state transitions with bounded render cadence to keep interactivity responsive without repaint storms.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/docs/internal/tui-runtime-internals.md
+++ b/docs/internal/tui-runtime-internals.md
@@ -227,4 +227,4 @@ Throttled/debounced paths:
 
 The runtime therefore mixes event-driven state transitions with bounded render cadence to keep interactivity responsive without repaint storms.
 
-*Verified against `72090e75` on 2026-07-20.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/tui-runtime-internals.md
+++ b/docs/internal/tui-runtime-internals.md
@@ -227,4 +227,4 @@ Throttled/debounced paths:
 
 The runtime therefore mixes event-driven state transitions with bounded render cadence to keep interactivity responsive without repaint storms.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/user-facing-packages.md
+++ b/docs/internal/user-facing-packages.md
@@ -49,4 +49,4 @@ There is no package README at this path today; the manifest and source headers a
 - Outputs: JSON result snapshots written to the adapter's `--output` path, plus conversation dumps in a sibling `result.dump/` directory.
 - Side effects/limits: extracts fixture archives to temp space and runs agent sessions against copied fixture inputs.
 
-*Verified against `72090e75` on 2026-07-20.*
+*Verified against `85b95ef5` on 2026-07-24.*

--- a/docs/internal/user-facing-packages.md
+++ b/docs/internal/user-facing-packages.md
@@ -49,4 +49,4 @@ There is no package README at this path today; the manifest and source headers a
 - Outputs: JSON result snapshots written to the adapter's `--output` path, plus conversation dumps in a sibling `result.dump/` directory.
 - Side effects/limits: extracts fixture archives to temp space and runs agent sessions against copied fixture inputs.
 
-*Verified against `b2e79db9` on 2026-07-24.*
+*Verified against `ab977ca4` on 2026-07-24.*

--- a/docs/internal/user-facing-packages.md
+++ b/docs/internal/user-facing-packages.md
@@ -49,4 +49,4 @@ There is no package README at this path today; the manifest and source headers a
 - Outputs: JSON result snapshots written to the adapter's `--output` path, plus conversation dumps in a sibling `result.dump/` directory.
 - Side effects/limits: extracts fixture archives to temp space and runs agent sessions against copied fixture inputs.
 
-*Verified against `85b95ef5` on 2026-07-24.*
+*Verified against `b2e79db9` on 2026-07-24.*

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
   "overrides": {
     "@ark/schema": "0.56.2",
     "tar": "^7.5.20",
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "brace-expansion": "5.0.8"
   },
   "scripts": {
     "setup": "bun install && bun run build:native && bun --cwd=packages/coding-agent link && sh scripts/link-veyyon.sh",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed in-progress aborts awaiting `session_stop` extension handlers whose results would be discarded ([#41](https://github.com/santhreal/veyyon/issues/41)).
+
 ## [1.0.37] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6061,6 +6061,10 @@ export class AgentSession {
 		messages: AgentMessage[],
 		lastAssistantMessage = this.getLastAssistantMessage(),
 	): Promise<void> {
+		if (this.#abortInProgress || this.#isDisposed) {
+			this.#resetSessionStopContinuationState();
+			return;
+		}
 		if (this.#agentKind === "sub" || !this.#extensionRunner?.hasHandlers("session_stop")) return;
 		const generation = this.#promptGeneration;
 		const result = await this.#extensionRunner.emitSessionStop({

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -453,6 +453,51 @@ describe("AgentSession concurrent prompt guard", () => {
 		).toBe(true);
 	});
 
+	it("does not emit session_stop when abort starts before the settle pass", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({
+			handler: () => ({ content: ["Done"] }),
+		});
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+			convertToLlm,
+		});
+		const settleGate = Promise.withResolvers<void>();
+		const settleReached = Promise.withResolvers<void>();
+		const emitSessionStop = vi.fn().mockResolvedValue(undefined);
+		const extensionRunner = {
+			emit: vi.fn().mockResolvedValue(undefined),
+			emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+			hasHandlers: vi.fn((eventType: string) => eventType === "session_stop"),
+			emitSessionStop,
+		} as unknown as ExtensionRunner;
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated();
+		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		authStorages.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry, extensionRunner });
+		vi.spyOn(session.goalRuntime, "onAgentEnd").mockImplementation(() => {
+			settleReached.resolve();
+			return settleGate.promise;
+		});
+
+		const promptPromise = session.prompt("First message");
+		await settleReached.promise;
+		const abortPromise = session.abort();
+		settleGate.resolve();
+
+		await abortPromise;
+		await promptPromise;
+		await session.waitForIdle();
+
+		expect(emitSessionStop).not.toHaveBeenCalled();
+	});
+
 	it("does not continue session_stop feedback after aborting a slow hook", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const mock = createMockModel({


### PR DESCRIPTION
Closes #41

Note: The changes to packages/coding-agent/src/prompts/system/workflow-notice.md from the upstream PR were skipped because Veyyon had previously rewritten this prompt file to remove the pipeline/parallel block that the diff modified.

---
*PR created automatically by Jules for task [9447471503340697682](https://jules.google.com/task/9447471503340697682) started by @santhreal*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session abort handling: when an abort starts mid-flight, the system no longer waits for session-stop processing that would be discarded, avoiding delayed or incorrect termination.
* **Tests**
  * Added a concurrency regression test to ensure the session-stop event is not emitted if abort begins before the settle phase completes.
* **Documentation**
  * Updated the changelog to document the in-progress abort fix and the prior behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->