### PR TITLE
port(upstream#6241): fix(extensibility): add Type.Unsafe to typebox shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the remapped TypeBox compatibility shim omitting `Type.Unsafe`, which crashed extensions such as `vey-mcp-adapter` when they registered tools from raw MCP input schemas.
+
 ## [1.0.37] - 2026-07-24
 
 ### Fixed

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -124,4 +124,4 @@ Pushes to other branches keep cancel-on-newer-push for fast feedback.
 `scripts/ci-concurrency.test.ts` locks the group and cancel expressions
 against regressions.
 
-*Verified against `d3e3db30` on 2026-07-23.*
+*Verified against `0b21a326` on 2026-07-24.*

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the remapped TypeBox compatibility shim omitting `Type.Unsafe`, which crashed extensions such as `vey-mcp-adapter` when they registered tools from raw MCP input schemas ([#6221](https://github.com/can1357/oh-my-pi/issues/6221)).
+
 ## [1.0.37] - 2026-07-24
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/typebox.ts
+++ b/packages/coding-agent/src/extensibility/typebox.ts
@@ -17,7 +17,7 @@
  * like a small validator at runtime.
  */
 
-import { areJsonValuesEqual, isMultipleOf } from "@veyyon/ai/utils/schema";
+import { areJsonValuesEqual, isMultipleOf, validateJsonSchemaValue } from "@veyyon/ai/utils/schema";
 import { codePointLength, isDateOnly, isRecord, isUuid } from "@veyyon/utils";
 
 // ---------------------------------------------------------------------------
@@ -42,6 +42,8 @@ export type TOptional<_E extends ArkSchema> = ArkSchema;
 export type TUnion<_T extends readonly ArkSchema[] = readonly ArkSchema[]> = ArkSchema;
 export type TEnum<_T extends readonly (string | number)[] = readonly (string | number)[]> = ArkSchema;
 export type TRecord<_K extends ArkSchema, _V extends ArkSchema> = ArkSchema;
+/** TypeBox-compatible wrapper for raw JSON Schema documents. */
+export type TUnsafe<_T = unknown> = ArkSchema;
 
 // ---------------------------------------------------------------------------
 // ArkSchema wrapper — JSON Schema object with hidden validator metadata
@@ -983,6 +985,17 @@ export const Type = {
 	Null: tNull,
 	Any: tAny,
 	Unknown: tUnknown,
+	Unsafe<T = unknown>(jsonSchema: Record<string, unknown> = {}): TUnsafe<T> {
+		const validator = (data: unknown): unknown => {
+			const result = validateJsonSchemaValue(jsonSchema, data);
+			if (result.success) return data;
+			const messages = result.issues.map(issue =>
+				issue.path.length > 0 ? `${issue.path.join(".")}: ${issue.message}` : issue.message,
+			);
+			return validationFailure(messages.join("; ") || "Invalid value");
+		};
+		return createArkSchema(validator, jsonSchema);
+	},
 	Never: tNever,
 	Literal: tLiteral,
 	Union: tUnion,

--- a/packages/coding-agent/test/extensibility/typebox-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-remap.test.ts
@@ -58,16 +58,23 @@ describe("legacy-pi TypeBox remap", () => {
 				'import { Type } from "typebox";',
 				"export const probe = Type;",
 				"export const enumSchema = Type.Enum(['upstream', 'downstream']);",
+				"export const unsafeSchema = Type.Unsafe({ type: 'object', properties: { path: { type: 'string' } }, required: ['path'] });",
 			].join("\n"),
 		);
 
 		const loaded = (await loadLegacyPiModule(entry)) as {
 			probe: typeof TypeBoxShimType;
 			enumSchema: { safeParse: (input: unknown) => { success: boolean } };
+			unsafeSchema: Record<string, unknown>;
 		};
 
 		expect(loaded.probe).toBe(TypeBoxShimType);
 		expect(loaded.enumSchema.safeParse("upstream").success).toBe(true);
 		expect(loaded.enumSchema.safeParse("sideways").success).toBe(false);
+		expect({ ...loaded.unsafeSchema }).toEqual({
+			type: "object",
+			properties: { path: { type: "string" } },
+			required: ["path"],
+		});
 	});
 });

--- a/packages/coding-agent/test/extensibility/typebox-shim.test.ts
+++ b/packages/coding-agent/test/extensibility/typebox-shim.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import type { Tool } from "@veyyon/ai/types";
 import { isValidJsonSchema, toolWireSchema } from "@veyyon/ai/utils/schema";
+import { validateToolArguments } from "@veyyon/ai/utils/validation";
 import { type TSchema, Type } from "@veyyon/coding-agent/extensibility/typebox";
 
 /**
@@ -23,6 +25,41 @@ describe("pi.typebox compatibility shim", () => {
 
 		expect(safeParse(schema, { path: "README.md" }).success).toBe(true);
 		expect(safeParse(schema, { path: "README.md", mode: "delete" }).success).toBe(false);
+	});
+
+	it("preserves and enforces raw JSON Schema wrapped with Type.Unsafe", () => {
+		const rawSchema = {
+			type: "object",
+			properties: { path: { type: "string" } },
+			required: ["path"],
+			additionalProperties: false,
+		};
+		const schema = Type.Unsafe<{ path: string }>(rawSchema);
+		const tool: Tool = { name: "unsafe-schema", description: "", parameters: schema };
+		const validArgs = { path: "README.md" };
+
+		expect(schema.__validator(validArgs)).toBe(validArgs);
+		expect(schema.safeParse({}).success).toBe(false);
+		const composed = Type.Object({ input: schema });
+		expect(composed.safeParse({ input: validArgs }).success).toBe(true);
+		expect(composed.safeParse({ input: {} }).success).toBe(false);
+		expect(toolWireSchema(tool)).toEqual(rawSchema);
+		expect(
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "valid",
+				name: tool.name,
+				arguments: validArgs,
+			}),
+		).toEqual(validArgs);
+		expect(() =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "invalid",
+				name: tool.name,
+				arguments: {},
+			}),
+		).toThrow('Validation failed for tool "unsafe-schema"');
 	});
 
 	it("preserves numeric enum values from TypeScript enum objects", () => {


### PR DESCRIPTION
Closes #63

Ported upstream PR #6241 which adds a `Type.Unsafe` builder to the typebox compatibility shim to correctly preserve and validate raw JSON schemas inside MCP integrations.

- Implemented `Type.Unsafe` in `packages/coding-agent/src/extensibility/typebox.ts`.
- Ported tests adapting to veyyon module locations.
- Adapted `pi-mcp-adapter` to `vey-mcp-adapter` in the changelog as per branding guidelines.
- Synced changelogs.

---
*PR created automatically by Jules for task [7153106321085805363](https://jules.google.com/task/7153106321085805363) started by @santhreal*