### PR TITLE
port(upstream#6225): fix(coding-agent): make hindsight request timeouts per-op and configurable

### DIFF
--- a/packages/coding-agent/src/config/settings-domains/context.ts
+++ b/packages/coding-agent/src/config/settings-domains/context.ts
@@ -881,6 +881,10 @@ export const CONTEXT_SETTINGS = {
 	"hindsight.recallContextTurns": { type: "number", default: 1 },
 	"hindsight.recallMaxQueryChars": { type: "number", default: 800 },
 	"hindsight.recallTypes": { type: "array", default: HINDSIGHT_RECALL_TYPES_DEFAULT },
+	"hindsight.requestTimeoutMs": { type: "number", default: 30_000 },
+	"hindsight.reflectTimeoutMs": { type: "number", default: 120_000 },
+	"hindsight.recallTimeoutMs": { type: "number", default: 30_000 },
+	"hindsight.retainTimeoutMs": { type: "number", default: 60_000 },
 
 	"hindsight.debug": { type: "boolean", default: false },
 

--- a/packages/coding-agent/src/hindsight/client.test.ts
+++ b/packages/coding-agent/src/hindsight/client.test.ts
@@ -31,6 +31,33 @@ describe("HindsightApi fetch cancellation", () => {
 		expect(requestSignal?.aborted).toBe(true);
 		expect(requestSignal?.reason).toBe(caller.signal.reason);
 	});
+
+	it("reports the effective per-op deadline in timeout errors", async () => {
+		const fetchStub = Object.assign(
+			async (_input: FetchInput, init?: FetchInit) => {
+				const err = new Error("Timeout");
+				err.name = "TimeoutError";
+				return Promise.reject(err);
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchStub);
+
+		const client = new HindsightApi({
+			baseUrl: "https://hindsight.example",
+			timeouts: { reflect: 90_000, recall: 15_000, request: 5_000 },
+		});
+
+		await expect(client.reflect("bank", "query")).rejects.toThrow(
+			"reflect request timed out after 90s"
+		);
+		await expect(client.recall("bank", "query")).rejects.toThrow(
+			"recall request timed out after 15s"
+		);
+		await expect(client.listDocuments("bank")).rejects.toThrow(
+			"listDocuments request timed out after 5s"
+		);
+	});
 });
 
 describe("HindsightApi User-Agent identity (SPEC-MEMORY #2)", () => {

--- a/packages/coding-agent/src/hindsight/client.ts
+++ b/packages/coding-agent/src/hindsight/client.ts
@@ -14,12 +14,18 @@ import type { HindsightConfig } from "./config";
 
 const USER_AGENT = "veyyon-coding-agent";
 const DEFAULT_USER_AGENT = USER_AGENT;
-const HINDSIGHT_REQUEST_TIMEOUT_MS = 30_000;
 
 export type Budget = "low" | "mid" | "high" | string;
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
 export type UpdateMode = "replace" | "append";
 export type ConsolidationState = "failed" | "pending" | "done";
+
+export interface HindsightTimeouts {
+	request?: number;
+	reflect?: number;
+	recall?: number;
+	retain?: number;
+}
 
 export interface HindsightApiOptions {
 	baseUrl: string;
@@ -222,6 +228,10 @@ interface RequestOptions {
 export class HindsightApi {
 	#baseUrl: string;
 	#headers: Record<string, string>;
+	#requestTimeoutMs: number;
+	#reflectTimeoutMs: number;
+	#recallTimeoutMs: number;
+	#retainTimeoutMs: number;
 
 	constructor(options: HindsightApiOptions) {
 		this.#baseUrl = trimTrailingSlashes(options.baseUrl);
@@ -232,6 +242,10 @@ export class HindsightApi {
 		if (options.apiKey) {
 			this.#headers.Authorization = `Bearer ${options.apiKey}`;
 		}
+		this.#requestTimeoutMs = options.timeouts?.request ?? 30_000;
+		this.#reflectTimeoutMs = options.timeouts?.reflect ?? 120_000;
+		this.#recallTimeoutMs = options.timeouts?.recall ?? 30_000;
+		this.#retainTimeoutMs = options.timeouts?.retain ?? 60_000;
 	}
 
 	async retain(bankId: string, content: string, options?: RetainOptions): Promise<RetainResponse> {
@@ -252,6 +266,7 @@ export class HindsightApi {
 			{
 				body: { items: [item], async: options?.async },
 				signal: options?.signal,
+				timeoutMs: this.#retainTimeoutMs,
 			},
 		);
 	}
@@ -283,6 +298,7 @@ export class HindsightApi {
 					async: options?.async,
 				},
 				signal: options?.signal,
+				timeoutMs: this.#retainTimeoutMs,
 			},
 		);
 	}
@@ -302,6 +318,7 @@ export class HindsightApi {
 					tags_match: options?.tagsMatch,
 				},
 				signal: options?.signal,
+				timeoutMs: this.#recallTimeoutMs,
 			},
 		);
 	}
@@ -320,6 +337,7 @@ export class HindsightApi {
 					tags_match: options?.tagsMatch,
 				},
 				signal: options?.signal,
+				timeoutMs: this.#reflectTimeoutMs,
 			},
 		);
 	}
@@ -507,10 +525,11 @@ export class HindsightApi {
 			if (qs) url += `?${qs}`;
 		}
 
+		const effectiveTimeoutMs = opts?.timeoutMs ?? this.#requestTimeoutMs;
 		const init: RequestInit = {
 			method,
 			headers: this.#headers,
-			signal: withTimeoutSignal(HINDSIGHT_REQUEST_TIMEOUT_MS, opts?.signal),
+			signal: withTimeoutSignal(effectiveTimeoutMs, opts?.signal),
 		};
 		if (opts?.body !== undefined) {
 			init.body = JSON.stringify(pruneUndefined(opts.body));
@@ -521,7 +540,7 @@ export class HindsightApi {
 			response = await fetch(url, init);
 		} catch (err) {
 			const message = isTimeoutError(err)
-				? `${operation} request timed out after 30s`
+				? `${operation} request timed out after ${Math.round(effectiveTimeoutMs / 1000)}s`
 				: `${operation} request failed: ${errorMessage(err)}`;
 			throw new HindsightError(message, undefined, err);
 		}

--- a/packages/coding-agent/src/hindsight/config.ts
+++ b/packages/coding-agent/src/hindsight/config.ts
@@ -40,6 +40,11 @@ export interface HindsightConfig {
 	recallMaxQueryChars: number;
 	recallPromptPreamble: string;
 
+	requestTimeoutMs: number;
+	reflectTimeoutMs: number;
+	recallTimeoutMs: number;
+	retainTimeoutMs: number;
+
 	debug: boolean;
 
 	mentalModelsEnabled: boolean;
@@ -115,6 +120,10 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 	const recallContextTurnsEnv = envInt(env.HINDSIGHT_RECALL_CONTEXT_TURNS);
 	const recallMaxQueryCharsEnv = envInt(env.HINDSIGHT_RECALL_MAX_QUERY_CHARS);
 	const retainEveryNTurnsEnv = envInt(env.HINDSIGHT_RETAIN_EVERY_N_TURNS);
+	const requestTimeoutMsEnv = envInt(env.HINDSIGHT_REQUEST_TIMEOUT_MS);
+	const reflectTimeoutMsEnv = envInt(env.HINDSIGHT_REFLECT_TIMEOUT_MS);
+	const recallTimeoutMsEnv = envInt(env.HINDSIGHT_RECALL_TIMEOUT_MS);
+	const retainTimeoutMsEnv = envInt(env.HINDSIGHT_RETAIN_TIMEOUT_MS);
 
 	// Read from settings (each falls back to its schema default).
 	const settingsRetainMode = pickRetainMode(settings.get("hindsight.retainMode"));
@@ -155,6 +164,11 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 		recallContextTurns: recallContextTurnsEnv ?? settings.get("hindsight.recallContextTurns"),
 		recallMaxQueryChars: recallMaxQueryCharsEnv ?? settings.get("hindsight.recallMaxQueryChars"),
 		recallPromptPreamble: DEFAULT_PREAMBLE,
+
+		requestTimeoutMs: requestTimeoutMsEnv ?? settings.get("hindsight.requestTimeoutMs"),
+		reflectTimeoutMs: reflectTimeoutMsEnv ?? settings.get("hindsight.reflectTimeoutMs"),
+		recallTimeoutMs: recallTimeoutMsEnv ?? settings.get("hindsight.recallTimeoutMs"),
+		retainTimeoutMs: retainTimeoutMsEnv ?? settings.get("hindsight.retainTimeoutMs"),
 
 		debug: debugEnv ?? settings.get("hindsight.debug"),
 

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -311,7 +311,8 @@ describe("retain.execute", () => {
 	it("emits a UI-only warning notice when the batch flush fails", async () => {
 		const settings = Settings.isolated({ "memory.backend": "hindsight" });
 		const client = new HindsightApi({ baseUrl: "http://localhost:8888" });
-		vi.spyOn(HindsightApi.prototype, "retainBatch").mockRejectedValue(new Error("HTTP 503"));
+		const fetchStub = async () => Promise.reject(new Error("HTTP 503"));
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchStub as any);
 		const noticeSpy = vi.fn();
 		registerState(client, settings, { sessionOverrides: { emitNotice: noticeSpy } });
 


### PR DESCRIPTION
Port upstream PR #6225 to the veyyon fork: make Hindsight request timeouts per-op and configurable.

Closes #42

---
*PR created automatically by Jules for task [13759816560059357706](https://jules.google.com/task/13759816560059357706) started by @santhreal*