### PR TITLE
docs(testing): detail whole-product Rust conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ python3 proof/verify-signature.py proof/captures/wayland/demo-hd-signature-cross
 | Parallel agents | Three subagents settling in one turn, one per directory, editing disjoint files against an owner the main agent wrote first | [frame](assets/demo-hd-agent-lanes.png) |
 | Edit | The main agent's own diff, adding the guard that rejects the hex, octal and binary literals its search flagged, with the file named in the block header | [frame](assets/demo-hd-edit-diff.png) |
 | Verification | The command the model chose to check its own change, and its output | [frame](assets/demo-hd-verify-command.png) |
-| Plan | A four-phase hardening plan opens before any file changes, advances through Migration and Validation, then closes after signing | [opened](assets/demo-hd-todo-board.png) / [advanced](assets/demo-hd-todo-strike.png) |
+| Plan | A four-phase hardening plan opens before any file changes and advances through Migration and Validation | [opened](assets/demo-hd-todo-board.png) / [advanced](assets/demo-hd-todo-strike.png) |
 | Secret stored | A credential taken from the environment, so it is typed nowhere | [frame](assets/demo-hd-secret-stored.png) |
 | Secret approval | The call held for approval, naming the credential it would spend | [frame](assets/demo-hd-secret-approval.png) |
 | Secret spent | The signature written from a placeholder the model never resolved | [frame](assets/demo-hd-signature-written.png) |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ python3 proof/verify-signature.py proof/captures/wayland/demo-hd-signature-cross
 | Parallel agents | Three subagents settling in one turn, one per directory, editing disjoint files against an owner the main agent wrote first | [frame](assets/demo-hd-agent-lanes.png) |
 | Edit | The main agent's own diff, adding the guard that rejects the hex, octal and binary literals its search flagged, with the file named in the block header | [frame](assets/demo-hd-edit-diff.png) |
 | Verification | The command the model chose to check its own change, and its output | [frame](assets/demo-hd-verify-command.png) |
-| Plan | A four-phase hardening plan opens before any file changes, advances through Migration and Validation, then closes after signing | [opened](assets/demo-hd-todo-board.png) / [advanced](assets/demo-hd-todo-strike.png) / [finished](assets/demo-hd-todo-finished.png) |
+| Plan | A four-phase hardening plan opens before any file changes, advances through Migration and Validation, then closes after signing | [opened](assets/demo-hd-todo-board.png) / [advanced](assets/demo-hd-todo-strike.png) |
 | Secret stored | A credential taken from the environment, so it is typed nowhere | [frame](assets/demo-hd-secret-stored.png) |
 | Secret approval | The call held for approval, naming the credential it would spend | [frame](assets/demo-hd-secret-approval.png) |
 | Secret spent | The signature written from a placeholder the model never resolved | [frame](assets/demo-hd-signature-written.png) |

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -620,7 +620,7 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 - Implement `vfs`, `vpty`, `vclock`, and `vmock` engines.
 - Build the 250,000-case generator, deduplication validator, and JSONL materializer.
 - Establish baseline JUnit and SARIF reporting.
-- Benchmark a complete compiled-product case on every supported platform; the p95 must be no greater than 600 ms before the three-minute CI target becomes binding.
+- Benchmark complete direct-Rust and compiled-product cases on every applicable platform. Before any wave joins the three-minute CI gate, direct-Rust p95 must be <= 1.5 ms, compiled-product p95 must be <= 500 ms, and three consecutive cold runs of every exact shard manifest must each finish in <= 144 seconds.
 
 ### Wave 1: Stateless Core, Configuration, Wire Protocols, and Argot
 
@@ -699,17 +699,21 @@ $$\text{slot}(c) = \text{BLAKE3}(c.\text{case\_id}) \pmod \text{runners\_in\_poo
 Each runner enforces a fixed four-slot compiled-product worker queue. A
 “complete compiled case” spans process launch, case execution, child exit,
 PTY/ConPTY closure, and normal workspace deletion or handoff to the bounded
-Windows cleanup queue. Wave 0 must record that complete-case p95 at no greater
-than 600 ms on every platform before the three-minute target becomes binding.
-A non-Linux pool runs 1,000 direct and 1,000 compiled cases; four process slots
-consume at most 150 seconds at the bound, leaving 29.4 seconds for queue drain
-and runner overhead. Each Linux runner receives about 60,250 direct cases and
-250 compiled cases; at 0.6 ms per direct case and 600 ms per compiled case, its
-budget is 73.65 seconds. The manifest rejects target/platform drift, missing
-runner eligibility, or shard skew that invalidates those bounds. The runner
-fails if its cleanup queue has not drained by the 180-second shard deadline. No
-claim depends on running the 250,000-case corpus once per platform or on 250,000
-independent process starts.
+Windows cleanup queue. A complete direct-Rust case includes fixture reset and
+oracle evaluation. Wave 0 establishes p95 limits of 1.5 ms for direct-Rust and
+500 ms for compiled-product cases on every applicable platform. Before each
+wave's exact manifest enters CI, three consecutive cold calibration runs of
+every shard must each finish in <= 144 seconds, preserving a 20% reserve below
+the hard deadline.
+
+A non-Linux runner's nominal p95 work is 1.5 seconds for 1,000 direct cases plus
+125 seconds for 1,000 compiled cases across four slots: 126.5 seconds. A Linux
+runner's nominal p95 work is 90.375 seconds for about 60,250 direct cases plus
+31.25 seconds for 250 compiled cases: 121.625 seconds. The manifest rejects
+target/platform drift, missing runner eligibility, shard skew, or calibration
+failure. A runner fails if its cleanup queue has not drained by the 180-second
+shard deadline. No claim depends on running the corpus once per platform or on
+250,000 independent process starts.
 
 ### 2. Deterministic Reporting Artifacts
 
@@ -760,5 +764,5 @@ The conformance migration is complete when all the following quantitative criter
 - [ ] **Mutation Proof**: Mutation engine executes >= 1,200 mutants, kills at least 1,000, and leaves zero survivors on credentials, authorization, path traversal, checksum verification, tool-call completeness, and persisted-version rejection.
 - [ ] **Simulations Deletion**: `packages/simulations` is deleted from disk and removed from workspace manifests.
 - [ ] **TypeScript Product-Test Deletion**: Zero superseded `*.test.ts` files remain in `packages/`; repository-governance checks under `scripts/` are retained or ported with parity.
-- [ ] **CI Performance**: Complete 250,000-case suite passes in < 3 minutes wall-clock time across eight CI shards after the Wave 0 p95 feasibility gate passes.
+- [ ] **CI Performance**: Direct-Rust p95 is <= 1.5 ms, compiled-product p95 is <= 500 ms, three cold calibrations of every exact shard finish in <= 144 seconds, and the complete 250,000-case CI run finishes in < 180 seconds across eight runners.
 - [ ] **Zero Unresolved Mismatches**: Every corpus mismatch is fixed or represented by an explicit reviewed contract change across Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64, and Windows x86_64.

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -167,7 +167,7 @@ The materialized conformance corpus contains exactly 250,000 distinct JSONL test
 | 07 | Security & Sandbox | Path traversal guards, credential boundary isolation, secret redaction, prompt injection fences, environment isolation | 14,000 | 384 |
 | 08 | CLI Engine & Modes | Argv parser, flag resolution, command dispatch, pipe mode, headless execution, TUI bootstrap, worker selectors | 16,000 | 256 |
 | 09 | Installers & Distribution | POSIX `install.sh`, Windows `install.ps1`, GitHub release asset verification, SHA-256 sidecars, self-updater | 10,000 | 192 |
-| 10 | Workers & Subprocesses | Tiny inference worker, JS eval worker, stats sync worker, tab worker, host entrypoint dispatch, IPC channels | 12,000 | 192 |
+| 10 | Native Services, Workers & Subprocesses | Native text/image/search bindings, tiny inference worker, JS eval worker, stats sync worker, tab worker, host dispatch, IPC channels | 12,000 | 192 |
 | 11 | Configuration & Settings | Domain schema validation, cascade resolution (Home -> Profile -> Project), conditions, env overrides, flag bindings | 12,000 | 192 |
 | 12 | Context & Compaction | Token budget accounting, sliding-window truncation, message compaction, TTSR injection, handoff generation | 14,000 | 224 |
 | 13 | Memory Engine & Vectors | Fact extraction, embedding vector math, similarity recall, query ranking, SQLite store, cache eviction | 12,000 | 160 |
@@ -609,7 +609,7 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 | [Wave 3: Agent & Safety]   --> Subsystems 03 Tools, 04 Sessions, 06 Concurrency, |
 |           |                07 Security, 12 Context                                |
 | [Wave 4: Product Surfaces] --> Subsystems 01 Rendering, 08 CLI, 09 Distribution,|
-|           |                10 Workers                                             |
+|           |                10 Native Services & Workers                           |
 | [Wave 5: Decommission]     --> Delete superseded TS tests and simulations; cut CI |
 +-----------------------------------------------------------------------------------+
 ```
@@ -633,15 +633,14 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 - Materialize exactly 42,000 cases and 720 error contracts.
 - **Gate**: 100% pass on the Wave 1 corpus through the migrated production crates and designated compiled-product cases; delete each corresponding TypeScript test only after the generated migration inventory proves one-for-one contract coverage.
 
-### Wave 2: Providers, Persistence, Memory, Native Support, and LSP
+### Wave 2: Providers, Persistence, Memory, and LSP
 
 - Port and verify Subsystems 02, 05, 13, and 15:
-  - `packages/natives` & `crates/veyyon-natives`
   - `packages/mnemopi` & SQLite persistence
   - `packages/ai` streaming and token accumulation
   - LSP JSON-RPC transport and diagnostics
 - Materialize exactly 62,000 cases and 1,056 error contracts.
-- **Gate**: 100% pass on the Wave 2 corpus; delete superseded tests in `packages/natives/test`, `packages/mnemopi/test`, and `packages/ai/test` only after inventory parity.
+- **Gate**: 100% pass on the Wave 2 corpus; delete superseded tests in `packages/mnemopi/test` and `packages/ai/test` only after inventory parity.
 
 ### Wave 3: Agent Runtime, Tools, Sessions, Concurrency, Security, and Context
 
@@ -652,15 +651,16 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 - Materialize exactly 88,000 cases and 1,696 error contracts.
 - **Gate**: 100% pass on the Wave 3 corpus; delete superseded tests in `packages/agent/test` and `packages/coding-agent` only after inventory parity.
 
-### Wave 4: TUI Rendering, CLI Modes, Workers, and Distribution
+### Wave 4: TUI Rendering, Native Services, CLI Modes, Workers, and Distribution
 
 - Port and verify Subsystems 01, 08, 09, and 10:
   - Terminal UI rendering across all viewports and dual grounds
+  - `packages/natives` and `crates/veyyon-natives` text, image, search, and filesystem services
   - Worker subprocess lifecycles (`stats`, `js_eval`, `tiny_inference`, `tab`)
   - CLI flag parsing, dispatch, and error output
   - Distribution installers (`install.sh`, `install.ps1`)
 - Materialize exactly 58,000 cases and 1,024 error contracts.
-- **Gate**: 100% pass on the Wave 4 corpus; delete superseded package tests and executable installer scenarios. Retain repository-policy and release-safety checks under `scripts/` unless they move to Rust repository-linter tooling with contract parity.
+- **Gate**: 100% pass on the Wave 4 corpus; delete superseded native/package tests and executable installer scenarios after inventory parity. Retain repository-policy and release-safety checks under `scripts/` unless they move to Rust repository-linter tooling with contract parity.
 
 ### Wave 5: Parity Certification, Simulation Deletion, and Final Cutover
 

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -68,12 +68,12 @@ The materialized conformance corpus contains exactly 250,000 distinct JSONL test
 
 | ID | Subsystem | Scope | Total Cases | Exact Error Contracts |
 |---|---|---|---|---|
-| 01 | Rendering & Terminal UI | Cell-grid layouts, ANSI sanitization, dual-ground raster proofs, streaming HUD, transcript rebuilds, wide/combining glyphs | 22,000 | 384 |
+| 01 | Rendering & Terminal UI | Cell-grid layouts, ANSI sanitization, dual-ground raster proofs, streaming HUD, transcript rebuilds, wide/combining glyphs | 20,000 | 384 |
 | 02 | AI Providers & Streaming | SSE parser, token accumulator, chunk streaming, error boundaries, auth retry, backoff jitter, thinking blocks | 24,000 | 480 |
-| 03 | Tool Execution Runtime | Tool dispatch, parameter validation, schema checks, process lifecycles, streaming preview decoders, timeout traps | 28,000 | 512 |
+| 03 | Tool Execution Runtime | Tool dispatch, parameter validation, schema checks, process lifecycles, streaming preview decoders, timeout traps | 26,000 | 512 |
 | 04 | Session & Tree Engine | Fork, resume, branch switching, history serialization, compaction checkpoints, export/share formats, tree merges | 20,000 | 320 |
-| 05 | Persistence & Mnemopi | SQLite storage, WAL lifecycle, schema migrations, triple index, vector recall, cache coherence, crash recovery | 18,000 | 256 |
-| 06 | Concurrency & Agent Mesh | Swarm mesh, IRC bus routing, subagent spawning, task worker pools, deadlock avoidance, lock hierarchies | 16,000 | 256 |
+| 05 | Persistence & Mnemopi | SQLite storage, WAL lifecycle, schema migrations, triple index, vector recall, cache coherence, crash recovery | 16,000 | 256 |
+| 06 | Concurrency & Agent Mesh | Swarm mesh, IRC bus routing, subagent spawning, task worker pools, deadlock avoidance, lock hierarchies | 14,000 | 256 |
 | 07 | Security & Sandbox | Path traversal guards, credential boundary isolation, secret redaction, prompt injection fences, environment isolation | 14,000 | 384 |
 | 08 | CLI Engine & Modes | Argv parser, flag resolution, command dispatch, pipe mode, headless execution, TUI bootstrap, worker selectors | 16,000 | 256 |
 | 09 | Installers & Distribution | POSIX `install.sh`, Windows `install.ps1`, GitHub release asset verification, SHA-256 sidecars, self-updater | 10,000 | 192 |
@@ -81,7 +81,7 @@ The materialized conformance corpus contains exactly 250,000 distinct JSONL test
 | 11 | Configuration & Settings | Domain schema validation, cascade resolution (Home -> Profile -> Project), conditions, env overrides, flag bindings | 12,000 | 192 |
 | 12 | Context & Compaction | Token budget accounting, sliding-window truncation, message compaction, TTSR injection, handoff generation | 14,000 | 224 |
 | 13 | Memory Engine & Vectors | Fact extraction, embedding vector math, similarity recall, query ranking, SQLite store, cache eviction | 12,000 | 160 |
-| 14 | Editing & Hashline Engine | Hashline syntax parsing, snapshot tag verification, hunk application, conflict resolution, AST rewrites, undo/redo | 18,000 | 288 |
+| 14 | Editing & Hashline Engine | Hashline syntax parsing, snapshot tag verification, hunk application, conflict resolution, AST rewrites, undo/redo | 16,000 | 288 |
 | 15 | LSP Client & Diagnostics | JSON-RPC transport, protocol framing, document synchronization, diagnostic parsing, symbol resolution, crash restart | 10,000 | 160 |
 | 16 | Wire Protocol & Argot | Collab wire messages, guest client relay, Argot shorthand codec, token boundary expansion, handle streaming | 14,000 | 240 |
 | **Total** | | | **250,000** | **4,496** |

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -2,6 +2,8 @@
 
 Technical architecture and implementation plan for replacing the TypeScript test surface and the simulations package (`packages/simulations`) with a unified Rust conformance crate (`crates/veyyon-conformance`).
 
+Tracking issue: [#877](https://github.com/santhreal/veyyon/issues/877).
+
 ## System Architecture
 
 The conformance engine is an out-of-process verification and differential testing harness located at `crates/veyyon-conformance`. It validates observable product behavior against formal specifications, deterministic state machines, and independent reference oracles.
@@ -156,6 +158,133 @@ The execution harness provides complete isolation and determinism without requir
   - Mid-stream network drops (`ECONNRESET`, `ETIMEDOUT`).
   - Injected upstream HTTP errors (`401 Unauthorized`, `429 Rate Limit Exceeded` with `Retry-After`, `500 Internal Server Error`, `503 Service Unavailable`).
   - Malformed SSE payloads (truncated JSON, invalid utf-8, unexpected thinking block structures).
+
+### 5. Source-Derived Provider Conformance Matrix
+
+Provider conformance begins at raw HTTP bytes and ends after session persistence
+and tool execution. Replacing a provider module with normalized events is not a
+provider conformance test because it bypasses framing, decoding, accumulation,
+terminal classification, and transport error handling.
+
+The corpus generator derives its provider population from production data:
+
+1. Enumerate every registered provider descriptor and bundled/custom model.
+2. Resolve each model's production API and compatibility policy.
+3. Group models by the parser and policy that execute them.
+4. Require every group to name a conformance policy and corpus allocation.
+5. Reject an unclassified provider, API, compatibility flag, or terminal policy.
+
+Provider names are metadata on cases, not a hardcoded test list. Adding a
+provider that resolves to `openai-completions`, for example, automatically
+places it in that wire matrix and makes the corpus count/digest gate red until
+the materialized cases are regenerated and reviewed.
+
+#### Raw framing dimensions
+
+For each applicable API and policy, `vmock` emits:
+
+- LF and CRLF SSE records;
+- comments, blank events, multiple `data:` fields, and unknown fields;
+- one SSE event per transport chunk;
+- several SSE events in one transport chunk;
+- every meaningful JSON token split boundary;
+- every UTF-8 code-point split boundary;
+- terminal and usage events in separate or combined transport chunks;
+- HTTP/1.1 chunked bodies and HTTP/2 data frames;
+- a socket that remains open after an authoritative terminal event.
+
+#### Semantic output dimensions
+
+The framing dimensions cross with:
+
+- no output and whitespace-only output;
+- text;
+- reasoning only;
+- reasoning followed by text;
+- one and several complete tool calls;
+- interleaved parallel tool-call deltas;
+- tool calls missing an id or name;
+- empty, truncated, malformed, primitive, array, and object arguments;
+- text plus complete or incomplete tool calls;
+- reasoning plus complete or incomplete tool calls.
+
+#### Terminal and failure dimensions
+
+The output shapes cross with:
+
+- `finish_reason` values `stop`, `tool_calls`, `length`, and content filtering;
+- provider refusal records;
+- usage before, with, and after the terminal event;
+- usage without an explicit finish reason;
+- `[DONE]` with and without semantic terminal output;
+- clean HTTP body EOF;
+- empty EOF;
+- `ECONNRESET`, `ETIMEDOUT`, DNS failure, TLS failure, and caller cancellation;
+- first-event and next-event timeouts;
+- malformed SSE, truncated JSON, and invalid UTF-8;
+- HTTP 401, 403, 408, 409, 429, 500, 502, 503, and 504;
+- `Retry-After` seconds and dates;
+- retry exhaustion and replay-unsafe partial batches.
+
+The generator uses pairwise/covering-array selection for noninteracting
+dimensions and exhaustive multiplication where dimensions interact, such as
+terminal signal by output completeness and transport fault by retry safety. The
+24,000 provider cases are fixed after semantic deduplication, not by truncating
+an oversized generated list.
+
+#### Required provider invariants
+
+Every matching case asserts all applicable invariants:
+
+- Clean EOF succeeds only for semantically self-contained output.
+- Reasoning-only clean EOF becomes bounded incomplete-output recovery, not a
+  successful empty answer.
+- Empty EOF remains a retryable incomplete-stream failure.
+- A transport exception never becomes clean EOF.
+- No incomplete tool call reaches execution.
+- A partial structured call wins over accompanying text or reasoning.
+- Complete parallel tool batches preserve ids, ordering, arguments, and replay
+  safety.
+- An authoritative terminal event settles within its deadline even when the
+  provider keeps the socket open.
+- Retry policy preserves the structured failure and never duplicates committed
+  output.
+- Persisted history contains the delivered attempt and excludes discarded retry
+  fragments.
+- Every retry, backoff, and timeout path terminates within its asserted bound.
+
+Each case records the exact emitted event sequence, final stop reason,
+structured content, error identity, retryability, recovery decision, persisted
+messages, tool side effects, and virtual-clock duration.
+
+#### Production incident intake
+
+Fleet incidents enter the corpus as synthetic structural fixtures. Raw sessions,
+prompts, assistant content, credentials, paths, and logs never enter the
+repository. A reducer maps each incident to:
+
+`API + compatibility policy + terminal signal + output shape + framing + fault + expected outcome`
+
+The canonical value is hashed before insertion. An existing hash links the
+incident to established coverage; a new hash creates a minimized generated case
+and mutation target. This closes a defect class without publishing conversation
+content or accumulating one fixture per model report.
+
+#### Compiled-product proof
+
+The direct parser corpus is necessary but insufficient. A compiled-product arm:
+
+1. Creates an isolated profile with generated provider/model configuration.
+2. Launches the release-mode Veyyon binary in noninteractive mode.
+3. Routes the selected model to `vmock`.
+4. Drives the raw wire case through model resolution, provider dispatch,
+   parsing, session policy, persistence, and tool execution.
+5. Asserts stdout/stderr, exit status, bounded termination, provider requests,
+   persisted session state, and filesystem side effects.
+
+The compiled arm samples every semantic family for every production provider
+policy. The direct parser arm performs exhaustive framing fragmentation. A
+generated coverage manifest proves that every provider policy appears in both.
 
 ---
 

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -127,6 +127,27 @@ contracts. The manifest computes both target totals, requires compiled coverage
 for all sixteen subsystems and every source-enumerated boundary family, and
 rejects drift. A case executes only the target declared in its record.
 
+The target/platform allocation is also exact:
+
+| Target | Platform | Cases |
+|---|---|---:|
+| `direct-rust` | platform-independent (`any`) | 240,000 |
+| `direct-rust` | Linux x86_64 | 1,000 |
+| `direct-rust` | Linux aarch64 | 1,000 |
+| `direct-rust` | macOS x86_64 | 1,000 |
+| `direct-rust` | macOS aarch64 | 1,000 |
+| `direct-rust` | Windows x86_64 | 1,000 |
+| `compiled-product` | Linux x86_64 | 1,000 |
+| `compiled-product` | Linux aarch64 | 1,000 |
+| `compiled-product` | macOS x86_64 | 1,000 |
+| `compiled-product` | macOS aarch64 | 1,000 |
+| `compiled-product` | Windows x86_64 | 1,000 |
+
+Platform-independent direct cases run once, not once per operating system.
+Platform-specific cases execute only on a matching runner. Each platform's
+compiled allocation must cover all sixteen subsystems and every
+platform-applicable source-enumerated boundary family.
+
 ---
 
 ## Corpus Allocation and Subsystem Contracts
@@ -163,17 +184,17 @@ The manifest generator computes both total columns from the sixteen allocations 
 
 To eliminate self-fulfilling tests and mock drift, the test harness adheres to strict execution invariants:
 
-1. **Zero Production Logic in Fakes**: No shadow reimplementations of TypeScript or Rust production logic exist in test helpers. All production code paths run from compiled binaries or un-instrumented native crates.
-2. **Migration Precedence**: Production logic must be ported to Rust crates (`crates/veyyon-*`) before Rust unit tests claim to cover it directly. TypeScript production logic is exercised strictly by driving the compiled CLI binary through virtual PTY, VFS, and virtual network interfaces.
-3. **Black-Box Process Boundaries**: The conformance harness drives `target/release/veyyon` via standard POSIX streams (`stdin`, `stdout`, `stderr`), pseudo-terminal devices, and injected virtual filesystem environments.
+1. **Zero Production Logic in Fakes**: No shadow reimplementations of TypeScript or Rust production logic exist in test helpers. Cases execute the compiled release artifact or migrated production crates through their production interfaces.
+2. **Migration Precedence**: Production logic must be ported to Rust crates (`crates/veyyon-*`) before direct-Rust cases claim to cover it. Remaining TypeScript behavior is exercised by driving the compiled CLI through external PTY/ConPTY, real isolated workspaces, and TCP loopback endpoints.
+3. **Black-Box Process Boundaries**: The conformance harness drives `target/release/veyyon` through standard streams, PTY/ConPTY devices, isolated profile/workspace directories, and configured loopback services. It does not inject code or virtual I/O implementations into the process.
 4. **Observable Contract Verification**: Assertions check observable output streams, filesystem state changes, exit codes, PTY cell grids, and wire packets. Internal function pointers, private variables, and memory layouts are not asserted.
-5. **No Mock Libraries**: Production code paths cannot link against mock-injecting libraries. All environment manipulation occurs outside the process boundary via interception at the operating system interface.
+5. **No Mock Libraries**: Production paths do not link against mock-injecting libraries. Direct-Rust cases substitute only external I/O traits; compiled-product cases manipulate the environment strictly outside the process and never interpose syscalls or dynamic libraries.
 
 ---
 
 ## Virtual Environment Subsystems
 
-The execution harness provides complete isolation and determinism without requiring root privileges or external containers.
+The harness provides target-appropriate isolation without root privileges or external containers. Direct-Rust cases are deterministically virtualized; compiled-product cases use black-box operating-system resources with deterministic external scripts and bounded real time.
 
 ```
 +-----------------------------------------------------------------------------------+
@@ -207,6 +228,7 @@ The execution harness provides complete isolation and determinism without requir
 - Injects `EIO`, `ENOSPC`, `EACCES`, partial writes, latency, and torn writes at that trait boundary and logs every operation for invariant checks.
 - Never claims to interpose operating-system syscalls in an unmodified binary.
 - Compiled-product cases instead launch in a unique real temporary workspace populated from the same content-addressed fixture. They use real permissions, quotas where portable, and crash boundaries; fault variants that cannot be induced portably remain direct-Rust cases.
+- The harness waits for child exit and PTY/ConPTY closure before workspace cleanup. On Windows it retries only `ERROR_ACCESS_DENIED` and sharing violations with bounded exponential backoff capped at five seconds per workspace; other cleanup errors fail immediately. A shard does not pass until its cleanup queue drains.
 
 ### 3. Virtual Clock and Deterministic Scheduler (`vclock`)
 
@@ -598,6 +620,7 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 - Implement `vfs`, `vpty`, `vclock`, and `vmock` engines.
 - Build the 250,000-case generator, deduplication validator, and JSONL materializer.
 - Establish baseline JUnit and SARIF reporting.
+- Benchmark a complete compiled-product case on every supported platform; the p95 must be no greater than 600 ms before the three-minute CI target becomes binding.
 
 ### Wave 1: Stateless Core, Configuration, Wire Protocols, and Argot
 
@@ -657,19 +680,36 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 
 ### 1. Parallel Sharding Strategy
 
-The corpus is sharded across exactly eight CI runners, leaving capacity under the
-repository's account-wide job ceiling:
+The corpus uses eight CI runners, leaving capacity under the repository's
+account-wide job ceiling:
 
-$$\text{Shard}(c) = \text{BLAKE3}(c.\text{case\_id}) \pmod 8$$
+| Runner pool | Runners | Eligible cases |
+|---|---:|---|
+| Linux x86_64 | 4 | `platform:any` plus Linux x86_64 |
+| Linux aarch64 | 1 | Linux aarch64 |
+| macOS x86_64 | 1 | macOS x86_64 |
+| macOS aarch64 | 1 | macOS aarch64 |
+| Windows x86_64 | 1 | Windows x86_64 |
 
-Each shard runs direct-Rust cases in-process and permits at most four concurrent
-compiled-product launches. Wave 0 must benchmark release-artifact startup and
-record a p95 no greater than 200 ms before the three-minute target becomes
-binding. At that bound, each shard receives about 625 compiled launches and
-31,250 total cases; four process slots consume at most 31.25 seconds of startup
-budget. The remaining direct-Rust budget is 148.75 seconds, or about 0.6 ms per
-case. The gate rejects a manifest whose target allocation or shard balance makes
-that budget impossible. No claim depends on 250,000 independent process starts.
+The dispatcher maps `platform:any` to the Linux x86_64 pool, maps every other
+case to its exact platform pool, then assigns:
+
+$$\text{slot}(c) = \text{BLAKE3}(c.\text{case\_id}) \pmod \text{runners\_in\_pool}(c)$$
+
+Each runner enforces a fixed four-slot compiled-product worker queue. A
+“complete compiled case” spans process launch, case execution, child exit,
+PTY/ConPTY closure, and normal workspace deletion or handoff to the bounded
+Windows cleanup queue. Wave 0 must record that complete-case p95 at no greater
+than 600 ms on every platform before the three-minute target becomes binding.
+A non-Linux pool runs 1,000 direct and 1,000 compiled cases; four process slots
+consume at most 150 seconds at the bound, leaving 29.4 seconds for queue drain
+and runner overhead. Each Linux runner receives about 60,250 direct cases and
+250 compiled cases; at 0.6 ms per direct case and 600 ms per compiled case, its
+budget is 73.65 seconds. The manifest rejects target/platform drift, missing
+runner eligibility, or shard skew that invalidates those bounds. The runner
+fails if its cleanup queue has not drained by the 180-second shard deadline. No
+claim depends on running the 250,000-case corpus once per platform or on 250,000
+independent process starts.
 
 ### 2. Deterministic Reporting Artifacts
 
@@ -715,6 +755,7 @@ The conformance migration is complete when all the following quantitative criter
 - [ ] **Error Coverage**: Exactly 4,496 specific expected-error contracts tested and verified across the 16 subsystems.
 - [ ] **Production Boundaries**: Every case drives either a migrated production Rust crate through its production boundary or the unmodified compiled release artifact. Test doubles exist only for external I/O.
 - [ ] **Target Allocation**: Exactly 245,000 cases execute in-process against production Rust and exactly 5,000 launch the compiled product; every subsystem and source-enumerated boundary family has compiled coverage.
+- [ ] **Platform Allocation**: Exactly 240,000 platform-independent direct cases plus 1,000 direct and 1,000 compiled cases for each of the five supported platform/architecture pairs execute on matching runners.
 - [ ] **UI Dual-Ground Verification**: All TUI components verified on both `#1e2127` and `#000000` grounds across all 6 terminal dimension profiles.
 - [ ] **Mutation Proof**: Mutation engine executes >= 1,200 mutants, kills at least 1,000, and leaves zero survivors on credentials, authorization, path traversal, checksum verification, tool-call completeness, and persisted-version rejection.
 - [ ] **Simulations Deletion**: `packages/simulations` is deleted from disk and removed from workspace manifests.

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -47,10 +47,10 @@ The `crates/veyyon-conformance` crate is partitioned into targeted modules:
 - `src/corpus/`: Schema definitions, deterministic serialization, materialization, and canonical BLAKE3 deduplication.
 - `src/generator/`: Combinatorial, grammar-based, and property-based case generators using reproducible PRNG seeds.
 - `src/oracle/`: Independent reference models, algebraic invariants, state-transition assertions, and schema validators.
-- `src/vfs/`: In-memory copy-on-write virtual filesystem with configurable POSIX fault injection (`EIO`, `ENOSPC`, `EACCES`, partial reads/writes, race windows).
-- `src/vpty/`: VT100/xterm pseudoterminal emulator capturing ANSI escape streams, terminal resize events, raw input feeds, and 2D cell-grid states.
-- `src/vclock/`: Virtual monotonic time provider controlling timers, tick schedules, timeout expirations, and deadline accelerations without wall-clock sleeps.
-- `src/vmock/`: HTTP/1.1 and HTTP/2 mock engine serving deterministically chunked Server-Sent Events (SSE), protocol jitter, token streaming, and simulated upstream outages.
+- `src/vfs/`: Trait-backed copy-on-write filesystem and POSIX fault injector for in-process Rust targets; real-workspace fixture materialization for compiled-product targets.
+- `src/vpty/`: Cross-platform PTY/ConPTY driver plus VT100/xterm parser capturing ANSI streams, resize events, raw input, and 2D cell-grid states.
+- `src/vclock/`: Virtual monotonic time and deterministic scheduling for in-process Rust targets; bounded real-time assertions for compiled-product targets.
+- `src/vmock/`: Cross-platform loopback HTTP/1.1 and HTTP/2 engine serving deterministically chunked Server-Sent Events (SSE), protocol jitter, token streaming, and simulated upstream outages.
 - `src/render/`: Dual-ground rasterizer and cell-grid comparator rendering ANSI output to pixel grids on `#1e2127` (grey) and `#000000` (black) grounds.
 - `src/fuzz/`: libFuzzer and AFL++ harnesses for raw parser inputs, wire formats, Argot codec tokens, and hashline patches.
 - `src/model_check/`: State-machine model checker verifying session tree invariants, state transitions, tool execution lifecycles, and lock acquisition graphs.
@@ -84,7 +84,7 @@ schema is versioned independently from production persistence formats:
   },
   "environment": {
     "platform": "linux-x64",
-    "clock": "virtual",
+    "clock": "real-bounded",
     "filesystemFixture": "blake3:...",
     "providerFixture": "blake3:..."
   },
@@ -117,6 +117,15 @@ fixture digest, rejects an unknown `schemaVersion`, and writes the corpus only
 after the unique-case and exact-error counts match their allocations. Execution
 results live in separate replay/report artifacts; a run never rewrites the
 committed oracle.
+
+The corpus has exactly 245,000 `direct-rust` cases and 5,000
+`compiled-product` cases. Direct cases exhaust parser, state-machine, scheduling,
+and fault combinations against migrated production crates. Compiled cases launch
+the unmodified release artifact and prove process wiring, configuration,
+persistence, PTY, provider transport, worker, installer, and distribution
+contracts. The manifest computes both target totals, requires compiled coverage
+for all sixteen subsystems and every source-enumerated boundary family, and
+rejects drift. A case executes only the target declared in its record.
 
 ---
 
@@ -188,33 +197,27 @@ The execution harness provides complete isolation and determinism without requir
 - Emulates standard terminal dimensions (configurable cols/rows from 20x5 to 400x120).
 - Implements full ANSI X3.64 / VT100 / xterm escape code parsing.
 - Maintains a real-time 2D cell grid containing character codepoints, foreground/background 24-bit RGB colors, bold, dim, italic, underline, inverse, and strikethrough attributes.
-- Simulates arbitrary terminal resize events (`SIGWINCH`) at designated clock ticks.
-- Injects raw byte sequences (keystrokes, bracketed paste, mouse events, signal keys `Ctrl+C`, `Ctrl+D`) with microsecond-accurate virtual timestamps.
+- Drives terminal resizes through `SIGWINCH` on POSIX and ConPTY resize calls on Windows.
+- Injects ordered raw byte sequences (keystrokes, bracketed paste, mouse events, signal keys `Ctrl+C`, `Ctrl+D`) and records the resulting ANSI stream.
 
 ### 2. Virtual Filesystem (`vfs`)
 
-- In-memory hierarchical filesystem implementing POSIX file semantics.
-- Provides copy-on-write isolation per test shard to eliminate test crosstalk.
-- Programmable Fault Injection Engine:
-  - `InjectFault::Eio(path_glob, operation_mask)`
-  - `InjectFault::Enospc(path_glob, threshold_bytes)`
-  - `InjectFault::Eacces(path_glob, permission_bits)`
-  - `InjectFault::PartialWrite(path_glob, max_bytes_per_call)`
-  - `InjectFault::Latency(path_glob, virtual_delay_micros)`
-  - `InjectFault::TornWrite(path_glob, crash_at_byte)`
-- Tracks all path operations (reads, writes, stats, readdirs, unlinks) for post-run invariant assertions.
+- Implements an in-memory filesystem behind the same narrow Rust I/O traits used by migrated production crates. Production builds bind those traits to the operating-system filesystem.
+- Provides copy-on-write isolation per direct-Rust shard.
+- Injects `EIO`, `ENOSPC`, `EACCES`, partial writes, latency, and torn writes at that trait boundary and logs every operation for invariant checks.
+- Never claims to interpose operating-system syscalls in an unmodified binary.
+- Compiled-product cases instead launch in a unique real temporary workspace populated from the same content-addressed fixture. They use real permissions, quotas where portable, and crash boundaries; fault variants that cannot be induced portably remain direct-Rust cases.
 
 ### 3. Virtual Clock and Deterministic Scheduler (`vclock`)
 
-- Intercepts time query syscalls (`clock_gettime`, `gettimeofday`) and runtime APIs.
-- Replaces wall-clock sleeps with instant discrete-event simulation ticks.
-- Guarantees identical execution ordering across varying CPU architectures and core counts.
-- Enforces deadline expiration and watchdog triggers deterministically.
+- Direct-Rust cases bind production timer interfaces to virtual monotonic time and a deterministic discrete-event scheduler.
+- Compiled-product cases use the production system clock. The harness controls external event delivery, uses short real deadlines, asserts termination plus an upper bound, and never asserts exact elapsed time.
+- No compiled-product case depends on `clock_gettime`/`gettimeofday` interposition, dynamic-library injection, or privileged clock control.
 
 ### 4. Virtual Mock Provider Engine (`vmock`)
 
-- Embedded HTTP/1.1 and HTTP/2 loopback server bound to ephemeral UNIX domain sockets.
-- Intercepts all outgoing LLM provider API requests (`OpenAI`, `Anthropic`, `Gemini`, `Ollama`, custom endpoints).
+- Embedded HTTP/1.1 and HTTP/2 server bound to ephemeral TCP loopback ports on every supported platform.
+- Routes provider traffic through production-configurable base URLs. A network-deny guard fails any unexpected non-loopback connection rather than replacing a provider module after parsing.
 - Delivers chunked Server-Sent Events (SSE) token by token, supporting:
   - Custom streaming chunk sizes (1 byte to 1024 bytes per chunk).
   - Mid-stream network drops (`ECONNRESET`, `ETIMEDOUT`).
@@ -421,15 +424,20 @@ The rendering engine verifies frame-by-frame equivalence between:
 Corpus records are generated via deterministic pseudorandom property engines:
 
 ```rust
-pub struct ConformanceTestCase {
-    pub case_id: [u8; 32],
-    pub subsystem_id: u16,
-    pub contract_id: u32,
-    pub input_vector: serde_json::Value,
-    pub env_config: VirtualEnvironmentConfig,
-    pub fault_plan: Option<FaultPlan>,
-    pub oracle_spec: OracleSpecification,
-    pub expected_outcome: ExpectedOutcome,
+#[serde(rename_all = "camelCase")]
+pub struct ConformanceCase {
+    pub schema_version: u16,
+    pub case_id: CaseId,
+    pub generator: GeneratorMetadata,
+    pub subsystem: SubsystemRef,
+    pub contract: ContractRef,
+    pub target: TargetSpec,
+    pub dimensions: BTreeMap<String, serde_json::Value>,
+    pub environment: EnvironmentSpec,
+    pub stimulus: Vec<Stimulus>,
+    pub oracle: OracleSpec,
+    pub coverage: CoverageSpec,
+    pub provenance: Provenance,
 }
 ```
 
@@ -439,13 +447,15 @@ pub struct ConformanceTestCase {
 
 ### 2. Deduplication and Collision Rejection
 
-Every test case is identified by a canonical BLAKE3 content digest calculated over its normalized semantic payload:
+Every test case is identified by a canonical BLAKE3 content digest:
 
-$$\text{Digest} = \text{BLAKE3}\left(\text{subsystem} \parallel \text{contract} \parallel \text{canonical\_json}(\text{input}) \parallel \text{fault\_plan} \parallel \text{oracle\_spec}\right)$$
+$$\text{Digest} = \text{BLAKE3}\left(\text{canonical\_json}\left(\{\text{subsystem},\text{contract},\text{target.kind},\text{dimensions},\text{environment},\text{stimulus},\text{oracle}\}\right)\right)$$
 
-- The corpus builder indexes all 250,000 cases in a lock-free hash set.
-- Duplicate case detection during generation immediately aborts the build with a duplicate key error.
-- All 250,000 cases in the committed corpus are mathematically unique.
+This is the same field set defined by the canonical record above. It excludes
+`caseId`, generator metadata, `target.entry`, `target.artifactDigest`, coverage
+labels, provenance, and execution observations. The corpus builder indexes all
+250,000 digests, rejects the first duplicate semantic identity, and writes rows
+in digest order.
 
 ### 3. Independent Oracles
 
@@ -556,7 +566,7 @@ The mutation engine injects the following structural defects into compiled crate
 
 - The engine evaluates a minimum of **1,200 distinct mutations** across critical production paths.
 - **Pass Requirement**: The test suite must kill at least **1,000 mutations** (minimum mutation score of **83.3%**).
-- Any mutant on security boundaries, path traversal guards, or hash verifiers that survives execution constitutes an immediate gate failure.
+- Mutants on credentials, authorization, path traversal, checksum verification, tool-call completeness, or persisted-version rejection have a zero-survivor requirement. One survivor fails the gate regardless of the aggregate score.
 
 ---
 
@@ -570,15 +580,15 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 +-----------------------------------------------------------------------------------+
 | [Wave 0: Infrastructure]  --> Scaffold crates/veyyon-conformance, VFS, VPTY, vmock |
 |           |                                                                       |
-| [Wave 1: Stateless Core]  --> Migrate Argot, Hashline, Wire, Utils, Catalog      |
+| [Wave 1: Stateless Core]  --> Subsystems 11 Configuration, 14 Editing, 16 Wire |
 |           |                                                                       |
-| [Wave 2: Native & State]  --> Migrate Natives, Persistence, Memory, AI Providers  |
-|           |                                                                       |
-| [Wave 3: Agent & Runtime] --> Migrate Coding Agent, Tools, Sessions, Compaction   |
-|           |                                                                       |
-| [Wave 4: UI & CLI Binary] --> Migrate TUI, Renderers, Workers, CLI Subcommands    |
-|           |                                                                       |
-| [Wave 5: Decommission]   --> Delete TS tests, Delete packages/simulations, CI Cut |
+| [Wave 2: State & Protocol] --> Subsystems 02 Providers, 05 Persistence,          |
+|           |                13 Memory, 15 LSP                                      |
+| [Wave 3: Agent & Safety]   --> Subsystems 03 Tools, 04 Sessions, 06 Concurrency, |
+|           |                07 Security, 12 Context                                |
+| [Wave 4: Product Surfaces] --> Subsystems 01 Rendering, 08 CLI, 09 Distribution,|
+|           |                10 Workers                                             |
+| [Wave 5: Decommission]     --> Delete superseded TS tests and simulations; cut CI |
 +-----------------------------------------------------------------------------------+
 ```
 
@@ -589,56 +599,57 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 - Build the 250,000-case generator, deduplication validator, and JSONL materializer.
 - Establish baseline JUnit and SARIF reporting.
 
-### Wave 1: Stateless Core, Parsers, Wire Protocols, and Argot
+### Wave 1: Stateless Core, Configuration, Wire Protocols, and Argot
 
-- Migrate each production implementation before claiming direct Rust coverage:
+- Migrate Subsystems 11, 14, and 16 before claiming direct Rust coverage:
   - `packages/argot` -> a production `veyyon-argot` crate
   - `packages/hashline` -> a production `veyyon-hashline` crate
   - `packages/wire` -> a production `veyyon-wire` crate
-  - `packages/catalog` -> production Rust catalog crates
+  - Catalog classification and configuration schema logic -> production Rust crates
 - Keep independent conformance oracles declarative: they describe invariants and expected records but never reimplement the production algorithm.
-- Materialize 35,000 cases and 560 error contracts.
-- **Gate**: 100% pass on the Wave 1 corpus through the migrated production crates and compiled product; delete each corresponding TypeScript test only after the generated migration inventory proves one-for-one contract coverage.
+- Materialize exactly 42,000 cases and 720 error contracts.
+- **Gate**: 100% pass on the Wave 1 corpus through the migrated production crates and designated compiled-product cases; delete each corresponding TypeScript test only after the generated migration inventory proves one-for-one contract coverage.
 
-### Wave 2: Native Subsystems, Persistence, Memory, and AI Providers
+### Wave 2: Providers, Persistence, Memory, Native Support, and LSP
 
-- Port and verify contracts for:
+- Port and verify Subsystems 02, 05, 13, and 15:
   - `packages/natives` & `crates/veyyon-natives`
   - `packages/mnemopi` & SQLite persistence
   - `packages/ai` streaming and token accumulation
-- Materialize 60,000 cases and 1,024 error contracts.
-- **Gate**: 100% pass on Wave 2 corpus; delete tests in `packages/natives/test`, `packages/mnemopi/test`, `packages/ai/test`.
+  - LSP JSON-RPC transport and diagnostics
+- Materialize exactly 62,000 cases and 1,056 error contracts.
+- **Gate**: 100% pass on the Wave 2 corpus; delete superseded tests in `packages/natives/test`, `packages/mnemopi/test`, and `packages/ai/test` only after inventory parity.
 
-### Wave 3: Agent Runtime, Tool Execution, Sessions, and Compaction
+### Wave 3: Agent Runtime, Tools, Sessions, Concurrency, Security, and Context
 
-- Port and verify contracts for:
-  - `packages/agent` core runtime
+- Port and verify Subsystems 03, 04, 06, 07, and 12:
+  - `packages/agent` core runtime and concurrency
   - `packages/coding-agent` tool execution pipeline, enumerated from the live registry so every current or newly added tool requires coverage
-  - Session branching, resume, checkpoints, compaction, TTSR
-- Materialize 75,000 cases and 1,408 error contracts.
-- **Gate**: 100% pass on Wave 3 corpus; delete tests in `packages/agent/test`, `packages/coding-agent/src/tools/**/test`.
+  - Session branching, resume, checkpoints, compaction, TTSR, and security boundaries
+- Materialize exactly 88,000 cases and 1,696 error contracts.
+- **Gate**: 100% pass on the Wave 3 corpus; delete superseded tests in `packages/agent/test` and `packages/coding-agent` only after inventory parity.
 
-### Wave 4: TUI Rendering, CLI Modes, Workers, and Installers
+### Wave 4: TUI Rendering, CLI Modes, Workers, and Distribution
 
-- Port and verify contracts for:
+- Port and verify Subsystems 01, 08, 09, and 10:
   - Terminal UI rendering across all viewports and dual grounds
   - Worker subprocess lifecycles (`stats`, `js_eval`, `tiny_inference`, `tab`)
   - CLI flag parsing, dispatch, and error output
   - Distribution installers (`install.sh`, `install.ps1`)
-- Materialize 80,000 cases and 1,504 error contracts.
-- **Gate**: 100% pass on Wave 4 corpus; delete tests in `packages/tui/test`, `packages/coding-agent/src/modes/**/test`, `scripts/install-tests`.
+- Materialize exactly 58,000 cases and 1,024 error contracts.
+- **Gate**: 100% pass on the Wave 4 corpus; delete superseded package tests and executable installer scenarios. Retain repository-policy and release-safety checks under `scripts/` unless they move to Rust repository-linter tooling with contract parity.
 
 ### Wave 5: Parity Certification, Simulation Deletion, and Final Cutover
 
-1. **Parity Certification**: Run complete 250,000-case suite against release binary; assert zero failures.
-2. **Mutation Gate Run**: Execute mutation engine; certify >= 1,000 killed mutants.
+1. **Parity Certification**: Run all 250,000 cases through the target declared by each canonical record; assert zero failures. The 5,000 compiled-product cases use the release artifact.
+2. **Mutation Gate Run**: Execute at least 1,200 mutations; certify at least 1,000 killed and zero critical-path survivors.
 3. **Simulation Package Fold & Deletion**:
    - Transfer any remaining non-redundant scenario definitions from `packages/simulations` into `crates/veyyon-conformance`.
    - Delete `packages/simulations` directory and remove workspace entries from `package.json` and `tsconfig.json`.
-4. **Final TS Test Elimination**: Delete all remaining `.test.ts` files across the workspace.
+4. **Final Product-Test Elimination**: Delete all superseded `.test.ts` files under `packages/`. Retain or explicitly port repository-governance checks under `scripts/`.
 5. **CI Pipeline Migration**:
-   - Update `.github/workflows/ci.yml` and `checks.yml` to remove `bun test` jobs.
-   - Wire `cargo test -p veyyon-conformance` with parallel sharding into the primary CI gate.
+   - Remove superseded package `bun test` jobs while preserving repository-governance script gates.
+   - Wire `cargo test -p veyyon-conformance` with bounded parallel sharding into the primary CI gate.
 
 ---
 
@@ -646,12 +657,19 @@ The migration from TypeScript test suites and `packages/simulations` to `crates/
 
 ### 1. Parallel Sharding Strategy
 
-The 250,000-case corpus is sharded across $N$ parallel CI runners (default $N=16$ or $N=32$):
+The corpus is sharded across exactly eight CI runners, leaving capacity under the
+repository's account-wide job ceiling:
 
-$$\text{Shard}(c) = \text{BLAKE3}(c.\text{case\_id}) \pmod N$$
+$$\text{Shard}(c) = \text{BLAKE3}(c.\text{case\_id}) \pmod 8$$
 
-- Deterministic hashing guarantees even distribution across shards without dynamic scheduling overhead.
-- Shards run concurrently with an execution budget ceiling of **< 3 minutes per shard** on standard 4-core runners.
+Each shard runs direct-Rust cases in-process and permits at most four concurrent
+compiled-product launches. Wave 0 must benchmark release-artifact startup and
+record a p95 no greater than 200 ms before the three-minute target becomes
+binding. At that bound, each shard receives about 625 compiled launches and
+31,250 total cases; four process slots consume at most 31.25 seconds of startup
+budget. The remaining direct-Rust budget is 148.75 seconds, or about 0.6 ms per
+case. The gate rejects a manifest whose target allocation or shard balance makes
+that budget impossible. No claim depends on 250,000 independent process starts.
 
 ### 2. Deterministic Reporting Artifacts
 
@@ -695,10 +713,11 @@ The conformance migration is complete when all the following quantitative criter
 
 - [ ] **Corpus Integrity**: Exactly 250,000 unique JSONL cases are materialized and checked in, one executable case per line, with a pinned generator seed and a canonical digest proving no duplicate semantic payloads.
 - [ ] **Error Coverage**: Exactly 4,496 specific expected-error contracts tested and verified across the 16 subsystems.
-- [ ] **No Parallel Fakes**: 100% of end-to-end conformance tests drive the compiled production binary or un-instrumented Rust crates.
+- [ ] **Production Boundaries**: Every case drives either a migrated production Rust crate through its production boundary or the unmodified compiled release artifact. Test doubles exist only for external I/O.
+- [ ] **Target Allocation**: Exactly 245,000 cases execute in-process against production Rust and exactly 5,000 launch the compiled product; every subsystem and source-enumerated boundary family has compiled coverage.
 - [ ] **UI Dual-Ground Verification**: All TUI components verified on both `#1e2127` and `#000000` grounds across all 6 terminal dimension profiles.
-- [ ] **Mutation Proof**: Mutation engine executes >= 1,200 mutants and successfully kills at least 1,000 mutants (mutation score >= 83.3%).
+- [ ] **Mutation Proof**: Mutation engine executes >= 1,200 mutants, kills at least 1,000, and leaves zero survivors on credentials, authorization, path traversal, checksum verification, tool-call completeness, and persisted-version rejection.
 - [ ] **Simulations Deletion**: `packages/simulations` is deleted from disk and removed from workspace manifests.
-- [ ] **TypeScript Test Deletion**: Zero `*.test.ts` files remain in `packages/` and `scripts/`.
-- [ ] **CI Performance**: Complete 250,000-case suite passes in < 3 minutes wall-clock time across 16 parallel CI shards.
+- [ ] **TypeScript Product-Test Deletion**: Zero superseded `*.test.ts` files remain in `packages/`; repository-governance checks under `scripts/` are retained or ported with parity.
+- [ ] **CI Performance**: Complete 250,000-case suite passes in < 3 minutes wall-clock time across eight CI shards after the Wave 0 p95 feasibility gate passes.
 - [ ] **Zero Unresolved Mismatches**: Every corpus mismatch is fixed or represented by an explicit reviewed contract change across Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64, and Windows x86_64.

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -58,6 +58,66 @@ The `crates/veyyon-conformance` crate is partitioned into targeted modules:
 - `src/shrink/`: Hierarchical delta-debugging engine that minimizes failing input sequences, environment sizes, and VFS trees into minimal reproducing test cases.
 - `src/report/`: Deterministic JUnit, SARIF, and JSON artifact reporter recording complete failure bundles with seed, VFS state, PTY log, and shrink traces.
 
+### Canonical Case Record
+
+Every materialized JSONL line is one self-contained `ConformanceCase`. The
+schema is versioned independently from production persistence formats:
+
+```json
+{
+  "schemaVersion": 1,
+  "caseId": "blake3:...",
+  "generator": { "version": "git:...", "seed": 1592639215 },
+  "subsystem": { "id": 2, "name": "ai-providers-streaming" },
+  "contract": { "id": "provider.clean-eof.complete-tool-batch", "expectedErrorId": null },
+  "target": {
+    "kind": "compiled-product",
+    "entry": "veyyon",
+    "artifactDigest": "sha256:..."
+  },
+  "dimensions": {
+    "api": "openai-completions",
+    "terminal": "clean-eof",
+    "outputShape": "complete-tool-batch",
+    "framing": "utf8-split",
+    "fault": "none"
+  },
+  "environment": {
+    "platform": "linux-x64",
+    "clock": "virtual",
+    "filesystemFixture": "blake3:...",
+    "providerFixture": "blake3:..."
+  },
+  "stimulus": [{ "kind": "prompt", "value": "fixture:provider/basic-tool-turn" }],
+  "oracle": {
+    "exitCode": 0,
+    "stopReason": "toolUse",
+    "errorId": null,
+    "maxVirtualMs": 2500,
+    "toolExecutions": [{ "name": "inspect", "count": 1 }],
+    "stdoutFixture": "blake3:...",
+    "persistedStateFixture": "blake3:..."
+  },
+  "coverage": {
+    "registryMembers": ["api:openai-completions", "provider:fixture"],
+    "requirements": ["provider-terminal-completeness", "tool-arguments-complete"]
+  },
+  "provenance": { "kind": "generated", "source": "provider-terminal-matrix" }
+}
+```
+
+`caseId` is the BLAKE3 digest of canonical JSON containing `subsystem`,
+`contract`, `target.kind`, `dimensions`, `environment`, `stimulus`, and
+`oracle`. It excludes `caseId`, generator metadata, execution observations, and
+provenance, so two generators cannot claim distinct coverage for the same
+semantic case. Fixture values are content-addressed and secrets are forbidden.
+
+The materializer writes rows sorted by `caseId`, validates every referenced
+fixture digest, rejects an unknown `schemaVersion`, and writes the corpus only
+after the unique-case and exact-error counts match their allocations. Execution
+results live in separate replay/report artifacts; a run never rewrites the
+committed oracle.
+
 ---
 
 ## Corpus Allocation and Subsystem Contracts

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -502,11 +502,11 @@ The mutation engine injects the following structural defects into compiled crate
 
 ## Migration Waves and Decommissioning Plan
 
-The migration from TypeScript test suites and `packages/simulations` to `crates/veyyon-conformance` proceeds in five sequential waves.
+The migration from TypeScript test suites and `packages/simulations` to `crates/veyyon-conformance` proceeds in six sequential waves, numbered 0 through 5.
 
 ```
 +-----------------------------------------------------------------------------------+
-|                            Five-Wave Migration Plan                               |
+|                             Six-Wave Migration Plan                              |
 +-----------------------------------------------------------------------------------+
 | [Wave 0: Infrastructure]  --> Scaffold crates/veyyon-conformance, VFS, VPTY, vmock |
 |           |                                                                       |

--- a/docs/internal/whole-product-rust-conformance.md
+++ b/docs/internal/whole-product-rust-conformance.md
@@ -86,6 +86,8 @@ The materialized conformance corpus contains exactly 250,000 distinct JSONL test
 | 16 | Wire Protocol & Argot | Collab wire messages, guest client relay, Argot shorthand codec, token boundary expansion, handle streaming | 14,000 | 240 |
 | **Total** | | | **250,000** | **4,496** |
 
+The manifest generator computes both total columns from the sixteen allocations and rejects the manifest unless they equal 250,000 and 4,496. The rendered total row is generated from those computed values; it is never an independently maintained literal.
+
 ---
 
 ## Production-Path Execution Rules


### PR DESCRIPTION
## Summary

- links the whole-product Rust conformance plan to tracking issue #877
- defines the canonical versioned case record, semantic BLAKE3 identity, content-addressed fixtures, and immutable oracle/report split
- partitions exactly 250,000 cases and 4,496 errors across every subsystem and migration wave, with computed drift gates
- allocates 245,000 direct-Rust and 5,000 compiled-product cases across five platform/architecture pairs and defines executable VFS, clock, PTY/ConPTY, and loopback-network boundaries
- defines source-derived provider/API coverage, raw SSE matrices, privacy-safe incident reduction, mutation guarantees, deterministic replay, and one-for-one TypeScript cutover

## Why this is a draft

This pull request is the review surface for the complete conformance migration tracked by #877. The current commit makes the architecture and provider contract executable enough to review before production migration begins. Implementation commits will accumulate here only after their production Rust ownership, corpus allocation, independent oracle, and old-to-new coverage mapping are identified.

This PR does not claim the migration is implemented. It must remain draft until every acceptance criterion in #877 is met, including the exact 250,000-case corpus, 4,496 expected-error contracts, mutation certification, compiled-product parity, and deletion of superseded TypeScript tests and `packages/simulations`.

## Review focus

1. Does every generated case execute production Rust or the compiled Veyyon product rather than a parallel fake?
2. Does registry-derived enumeration fail closed when a provider, API, tool, setting, worker, or route is added?
3. Are raw provider bytes exercised before parsing, including framing splits and transport faults?
4. Are the corpus and exact-error allocations coherent and reproducible?
5. Is the migration order sufficient to prevent deleting old coverage before parity is demonstrated?
6. Do mutation and replay requirements prove test sensitivity and make failures reproducible?

## Verification

- workspace TypeScript checks passed in the pre-push hook
- documentation link checker passes across 1,538 internal links after the stale README artifact reference was removed from `main`
- subsystem and migration-wave allocations independently sum to exactly 250,000 cases and 4,496 error contracts
- target allocations independently sum to 245,000 direct-Rust and 5,000 compiled-product cases
- platform allocation is exactly 240,000 platform-independent direct cases plus 1,000 direct and 1,000 compiled cases on each supported platform; direct p95 <= 1.5 ms, compiled p95 <= 500 ms, and three cold calibrations per shard at <= 144 seconds bound the eight-runner gate below 180 seconds
- five independent review passes verified corpus/schema coherence, provider/runtime completeness, platform-harness feasibility, migration/mutation safety, and adversarial issue/design agreement; the reported boundary and Windows-cleanup gaps are closed
- Devin findings corrected the original 260,000-case allocation, per-shard throughput arithmetic, and previously implicit native-services ownership; final review marked the native finding resolved and reported no new issue
- final-head Docs passed; draft Checks and CI were canceled to return runners to the v1.1.1 publication workflow and must rerun before the PR leaves draft

Tracks #877.
