### PR TITLE
feat(coding-agent): add search/filter to /providers account manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `/omfg` forges rules that carry the extended TTSR frontmatter (`astCondition`, `interruptMode`, `pathScope`, `repeatMode`, `repeatGap`, `repeatCompactions`, `warmupMatches`), confirms ast-grep conditions against the conversation's tool history through the same gate chain a live stream applies, and fails loudly on a malformed optional field instead of dropping it.
 - `/omfg` saves forged rules to the active profile's rules directory only; the project target is gone, because project `.veyyon/rules` was never discovered across sessions.
 - Settings → Stream Interrupts (TTSR) groups the profile's own rules under a leading `User created` section instead of `From native`, ahead of foreign-tool and built-in sections.
+- Added interactive search and filtering to the /providers account manager sidebar with real-time fuzzy matching across provider names and IDs, keyboard navigation parity and Escape/Backspace to clear (Refs #885).
 - A ChatGPT OAuth (Codex) session compacts server-side via the Responses compaction endpoint, preserving encrypted reasoning state.
 - `ToolCallLoopGuard` detects consecutive redundant reads of unchanged files whose requested line ranges are already fully present in recent context, steering runaway exploration loops while preserving prompt cache prefixes.
 - Added Command Code API-key login through the Studio Provider page, with validation against its Provider API, and Nous Research Portal OAuth device login with rotating refresh tokens and short-lived inference JWTs.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `/omfg` forges rules that carry the extended TTSR frontmatter (`astCondition`, `interruptMode`, `pathScope`, `repeatMode`, `repeatGap`, `repeatCompactions`, `warmupMatches`), confirms ast-grep conditions against the conversation's tool history through the same gate chain a live stream applies, and fails loudly on a malformed optional field instead of dropping it.
 - `/omfg` saves forged rules to the active profile's rules directory only; the project target is gone, because project `.veyyon/rules` was never discovered across sessions.
 - Settings → Stream Interrupts (TTSR) groups the profile's own rules under a leading `User created` section instead of `From native`, ahead of foreign-tool and built-in sections.
+- Added interactive search and filtering to the /providers account manager sidebar with real-time fuzzy matching across provider names and IDs, keyboard navigation parity and Escape/Backspace to clear (Refs #885).
 
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/account-manager-search.test.ts
+++ b/packages/coding-agent/src/modes/components/account-manager-search.test.ts
@@ -34,21 +34,23 @@ function makeSeededInventory(): AccountInventory {
 	const providers: ProviderAccounts[] = [
 		{ provider: "anthropic", label: "Anthropic", rows: [makeRow("anthropic", "Anthropic", 1)] },
 		{ provider: "openai", label: "OpenAI", rows: [makeRow("openai", "OpenAI", 2)] },
-		{ provider: "groq", label: "Groq", rows: [makeRow("groq", "Groq", 3)] },
-		{ provider: "google", label: "Google", rows: [makeRow("google", "Google", 4)] },
+		// Distinct id vs label: id contains "codex", label "Codex" — proves filter hits id+label
+		{ provider: "openai-codex", label: "Codex", rows: [makeRow("openai-codex", "Codex", 3)] },
+		{ provider: "groq", label: "Groq", rows: [makeRow("groq", "Groq", 4)] },
+		{ provider: "google", label: "Google", rows: [makeRow("google", "Google", 5)] },
+		// Id holds "xyz" not present in label "CustomAlpha" — proves id-only match
+		{ provider: "custom-id-xyz", label: "CustomAlpha", rows: [makeRow("custom-id-xyz", "CustomAlpha", 6)] },
 	];
-	return { providers, totalAccounts: 4, unhealthyCount: 0 };
+	return { providers, totalAccounts: 6, unhealthyCount: 0 };
 }
-function makeEmptyInventory(): AccountInventory {
-	return makeSeededInventory();
-}
+
 describe("AccountManager search/filter", () => {
 	beforeAll(async () => {
 		await initTheme();
 	});
 
 	it("shows Type to search and filters to matching providers only", () => {
-		const inventory = makeEmptyInventory();
+		const inventory = makeSeededInventory();
 		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
 		const firstRender = component.render(80).join("\n");
 		expect(firstRender).toContain("Type to search");
@@ -61,6 +63,8 @@ describe("AccountManager search/filter", () => {
 		expect(filteredRender).toContain("Anthropic");
 		expect(filteredRender).not.toContain("Groq");
 		expect(filteredRender).not.toContain("Google");
+		expect(filteredRender).not.toContain("Codex");
+		expect(filteredRender).not.toContain("CustomAlpha");
 
 		component.handleInput("\x1b");
 		expect(component.hasActiveSearch()).toBe(false);
@@ -71,8 +75,31 @@ describe("AccountManager search/filter", () => {
 		component.dispose();
 	});
 
+	it("filters by provider id when label does not contain query", () => {
+		const inventory = makeSeededInventory();
+		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
+		component.render(80);
+		component.handleInput("\x1b[D");
+		for (const ch of "xyz") component.handleInput(ch);
+		expect(component.hasActiveSearch()).toBe(true);
+		const filtered = component.render(80).join("\n");
+		expect(filtered).toContain("Search: xyz");
+		expect(filtered).toContain("CustomAlpha");
+		expect(filtered).not.toContain("Anthropic");
+		expect(filtered).not.toContain("OpenAI");
+		expect(filtered).not.toContain("Codex");
+		// Backspace stepwise still filters
+		component.handleInput("\x7f");
+		expect(component.hasActiveSearch()).toBe(true);
+		expect(component.render(80).join("\n")).toContain("Search: xy");
+		expect(component.render(80).join("\n")).toContain("CustomAlpha");
+		component.handleInput("\x1b");
+		expect(component.hasActiveSearch()).toBe(false);
+		component.dispose();
+	});
+
 	it("shows No matching providers and hides all provider rows when nothing matches", () => {
-		const inventory = makeEmptyInventory();
+		const inventory = makeSeededInventory();
 		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
 		component.render(80);
 		component.handleInput("\x1b[D");
@@ -83,6 +110,8 @@ describe("AccountManager search/filter", () => {
 		expect(noMatch).not.toContain("Anthropic");
 		expect(noMatch).not.toContain("Groq");
 		expect(noMatch).not.toContain("OpenAI");
+		expect(noMatch).not.toContain("Codex");
+		expect(noMatch).not.toContain("CustomAlpha");
 
 		component.handleInput("\x7f");
 		expect(component.hasActiveSearch()).toBe(true);
@@ -94,31 +123,43 @@ describe("AccountManager search/filter", () => {
 		component.dispose();
 	});
 
-	it("arrow navigation stays within filtered providers", () => {
-		const inventory = makeEmptyInventory();
+	it("arrow navigation stays within filtered providers and wraps", () => {
+		const inventory = makeSeededInventory();
 		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
 		component.render(80);
 		component.handleInput("\x1b[D");
+		// "open" matches exactly 2 providers: OpenAI and Codex (openai-codex)
 		for (const ch of "open") component.handleInput(ch);
 		expect(component.hasActiveSearch()).toBe(true);
 		const before = component.render(80).join("\n");
 		expect(before).toContain("Search: open");
 		expect(before).toContain("OpenAI");
+		expect(before).toContain("Codex");
 		expect(before).not.toContain("Anthropic");
+		expect(before).not.toContain("Groq");
+		expect(before).not.toContain("CustomAlpha");
 
+		// Down moves within filtered set, never leaks unfiltered provider
 		component.handleInput("\x1b[B");
 		let afterDown = component.render(80).join("\n");
 		expect(afterDown).toContain("Search: open");
-		expect(afterDown).not.toContain("Anthropic");
 		expect(afterDown).toContain("OpenAI");
+		expect(afterDown).toContain("Codex");
+		expect(afterDown).not.toContain("Anthropic");
+		expect(afterDown).not.toContain("CustomAlpha");
 
 		component.handleInput("\x1b[B");
 		afterDown = component.render(80).join("\n");
+		expect(afterDown).toContain("Search: open");
+		expect(afterDown).toContain("OpenAI");
+		expect(afterDown).toContain("Codex");
 		expect(afterDown).not.toContain("Anthropic");
 
 		component.handleInput("\x1b[A");
 		const afterUp = component.render(80).join("\n");
 		expect(afterUp).toContain("Search: open");
+		expect(afterUp).toContain("OpenAI");
+		expect(afterUp).toContain("Codex");
 		expect(afterUp).not.toContain("Anthropic");
 
 		component.dispose();

--- a/packages/coding-agent/src/modes/components/account-manager-search.test.ts
+++ b/packages/coding-agent/src/modes/components/account-manager-search.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
-import type { AccountInventory } from "../../session/account-inventory";
+import type { AccountInventory, AccountRow, ProviderAccounts } from "../../session/account-inventory";
 import { initTheme } from "../theme/theme";
 import { AccountManagerComponent } from "./account-manager";
 
@@ -17,26 +17,27 @@ function makeCallbacks() {
 	};
 }
 
+function makeRow(provider: string, label: string, credentialId: number): AccountRow {
+	return {
+		provider,
+		providerLabel: label,
+		credentialId,
+		type: "api_key",
+		usage: [],
+		activeForSession: false,
+		activeIsPrediction: false,
+		selectedForProvider: false,
+	};
+}
+
 function makeSeededInventory(): AccountInventory {
-	const providers = [
-		{
-			provider: "anthropic",
-			label: "Anthropic",
-			rows: [{ provider: "anthropic", providerLabel: "Anthropic", credentialId: 1 } as any],
-		},
-		{
-			provider: "openai",
-			label: "OpenAI",
-			rows: [{ provider: "openai", providerLabel: "OpenAI", credentialId: 2 } as any],
-		},
-		{ provider: "groq", label: "Groq", rows: [{ provider: "groq", providerLabel: "Groq", credentialId: 3 } as any] },
-		{
-			provider: "google",
-			label: "Google",
-			rows: [{ provider: "google", providerLabel: "Google", credentialId: 4 } as any],
-		},
-	] as any;
-	return { providers, totalAccounts: 4, unhealthyCount: 0 } as AccountInventory;
+	const providers: ProviderAccounts[] = [
+		{ provider: "anthropic", label: "Anthropic", rows: [makeRow("anthropic", "Anthropic", 1)] },
+		{ provider: "openai", label: "OpenAI", rows: [makeRow("openai", "OpenAI", 2)] },
+		{ provider: "groq", label: "Groq", rows: [makeRow("groq", "Groq", 3)] },
+		{ provider: "google", label: "Google", rows: [makeRow("google", "Google", 4)] },
+	];
+	return { providers, totalAccounts: 4, unhealthyCount: 0 };
 }
 function makeEmptyInventory(): AccountInventory {
 	return makeSeededInventory();

--- a/packages/coding-agent/src/modes/components/account-manager-search.test.ts
+++ b/packages/coding-agent/src/modes/components/account-manager-search.test.ts
@@ -17,9 +17,29 @@ function makeCallbacks() {
 	};
 }
 
+function makeSeededInventory(): AccountInventory {
+	const providers = [
+		{
+			provider: "anthropic",
+			label: "Anthropic",
+			rows: [{ provider: "anthropic", providerLabel: "Anthropic", credentialId: 1 } as any],
+		},
+		{
+			provider: "openai",
+			label: "OpenAI",
+			rows: [{ provider: "openai", providerLabel: "OpenAI", credentialId: 2 } as any],
+		},
+		{ provider: "groq", label: "Groq", rows: [{ provider: "groq", providerLabel: "Groq", credentialId: 3 } as any] },
+		{
+			provider: "google",
+			label: "Google",
+			rows: [{ provider: "google", providerLabel: "Google", credentialId: 4 } as any],
+		},
+	] as any;
+	return { providers, totalAccounts: 4, unhealthyCount: 0 } as AccountInventory;
+}
 function makeEmptyInventory(): AccountInventory {
-	const inventory = { providers: [], totalAccounts: 0, unhealthyCount: 0 } as AccountInventory;
-	return inventory;
+	return makeSeededInventory();
 }
 describe("AccountManager search/filter", () => {
 	beforeAll(async () => {

--- a/packages/coding-agent/src/modes/components/account-manager-search.test.ts
+++ b/packages/coding-agent/src/modes/components/account-manager-search.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { getOAuthProviders } from "@veyyon/ai/oauth";
+import type { AccountInventory } from "../../session/account-inventory";
+import { initTheme } from "../theme/theme";
+import { AccountManagerComponent } from "./account-manager";
+
+function makeCallbacks() {
+	return {
+		onUseAccount: () => {},
+		onRename: () => {},
+		onRefresh: () => {},
+		onLogout: () => {},
+		onShowUsage: () => {},
+		onAddAccount: () => {},
+		onToggleLoadBalancing: () => false,
+		onClearRateLimitBlock: () => {},
+		onCancel: () => {},
+	};
+}
+
+function makeEmptyInventory(): AccountInventory {
+	const inventory = { providers: [] } as AccountInventory;
+	return inventory;
+}
+
+describe("AccountManager search/filter", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	it("shows Type to search and filters on typing with keyboard parity", () => {
+		const inventory = makeEmptyInventory();
+		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
+		const firstRender = component.render(80).join("\n");
+		expect(firstRender).toContain("Type to search");
+
+		// Focus sidebar (initial focus is body)
+		component.handleInput("\x1b[D");
+		component.handleInput("a");
+		component.handleInput("n");
+		component.handleInput("t");
+		expect(component.hasActiveSearch()).toBe(true);
+		const filteredRender = component.render(80).join("\n");
+		expect(filteredRender).toContain("Search: ant");
+		// filtered list should contain Anthropic but not all providers; check that output shrank
+		const allProviders = getOAuthProviders();
+		const anthropic = allProviders.find(p => p.id === "anthropic");
+		expect(anthropic).toBeDefined();
+		// Render should still contain Anthropic label, but not arbitrary other provider when filtered narrowly
+		// Use a query that isolates one provider
+		component.handleInput("\x1b"); // Esc clears
+		expect(component.hasActiveSearch()).toBe(false);
+		const clearedRender = component.render(80).join("\n");
+		expect(clearedRender).toContain("Type to search");
+		expect(clearedRender).not.toContain("Search: ant");
+
+		component.dispose();
+	});
+
+	it("shows No matching providers for nonsense query and clears via Backspace/Escape", () => {
+		const inventory = makeEmptyInventory();
+		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
+		component.render(80);
+		component.handleInput("\x1b[D");
+		for (const ch of "zzz_no_such_provider_zzz") component.handleInput(ch);
+		expect(component.hasActiveSearch()).toBe(true);
+		const noMatch = component.render(80).join("\n");
+		expect(noMatch).toContain("No matching providers");
+
+		// Backspace should pop one char and still be active
+		component.handleInput("\x7f");
+		expect(component.hasActiveSearch()).toBe(true);
+
+		// Esc clears
+		component.handleInput("\x1b");
+		expect(component.hasActiveSearch()).toBe(false);
+		expect(component.render(80).join("\n")).toContain("Type to search");
+
+		component.dispose();
+	});
+
+	it("arrow navigation wraps filtered list", () => {
+		const inventory = makeEmptyInventory();
+		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
+		component.render(80);
+		component.handleInput("\x1b[D");
+		// Filter to a small subset e.g. "open" matches openai, openai-codex, openrouter
+		for (const ch of "open") component.handleInput(ch);
+		expect(component.hasActiveSearch()).toBe(true);
+		const before = component.render(80).join("\n");
+		expect(before).toContain("Search: open");
+
+		// Arrow down should change active provider within filtered set
+		component.handleInput("\x1b[B");
+		component.handleInput("\x1b[B");
+		// Arrow up wraps
+		component.handleInput("\x1b[A");
+		// Should not throw and should still be filtered
+		expect(component.hasActiveSearch()).toBe(true);
+		expect(component.render(80).join("\n")).toContain("Search: open");
+
+		component.dispose();
+	});
+});

--- a/packages/coding-agent/src/modes/components/account-manager-search.test.ts
+++ b/packages/coding-agent/src/modes/components/account-manager-search.test.ts
@@ -1,5 +1,4 @@
 import { beforeAll, describe, expect, it } from "bun:test";
-import { getOAuthProviders } from "@veyyon/ai/oauth";
 import type { AccountInventory } from "../../session/account-inventory";
 import { initTheme } from "../theme/theme";
 import { AccountManagerComponent } from "./account-manager";
@@ -19,45 +18,39 @@ function makeCallbacks() {
 }
 
 function makeEmptyInventory(): AccountInventory {
-	const inventory = { providers: [] } as AccountInventory;
+	const inventory = { providers: [], totalAccounts: 0, unhealthyCount: 0 } as AccountInventory;
 	return inventory;
 }
-
 describe("AccountManager search/filter", () => {
 	beforeAll(async () => {
 		await initTheme();
 	});
 
-	it("shows Type to search and filters on typing with keyboard parity", () => {
+	it("shows Type to search and filters to matching providers only", () => {
 		const inventory = makeEmptyInventory();
 		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
 		const firstRender = component.render(80).join("\n");
 		expect(firstRender).toContain("Type to search");
 
-		// Focus sidebar (initial focus is body)
 		component.handleInput("\x1b[D");
-		component.handleInput("a");
-		component.handleInput("n");
-		component.handleInput("t");
+		for (const ch of "anth") component.handleInput(ch);
 		expect(component.hasActiveSearch()).toBe(true);
 		const filteredRender = component.render(80).join("\n");
-		expect(filteredRender).toContain("Search: ant");
-		// filtered list should contain Anthropic but not all providers; check that output shrank
-		const allProviders = getOAuthProviders();
-		const anthropic = allProviders.find(p => p.id === "anthropic");
-		expect(anthropic).toBeDefined();
-		// Render should still contain Anthropic label, but not arbitrary other provider when filtered narrowly
-		// Use a query that isolates one provider
-		component.handleInput("\x1b"); // Esc clears
+		expect(filteredRender).toContain("Search: anth");
+		expect(filteredRender).toContain("Anthropic");
+		expect(filteredRender).not.toContain("Groq");
+		expect(filteredRender).not.toContain("Google");
+
+		component.handleInput("\x1b");
 		expect(component.hasActiveSearch()).toBe(false);
 		const clearedRender = component.render(80).join("\n");
 		expect(clearedRender).toContain("Type to search");
-		expect(clearedRender).not.toContain("Search: ant");
+		expect(clearedRender).not.toContain("Search: anth");
 
 		component.dispose();
 	});
 
-	it("shows No matching providers for nonsense query and clears via Backspace/Escape", () => {
+	it("shows No matching providers and hides all provider rows when nothing matches", () => {
 		const inventory = makeEmptyInventory();
 		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
 		component.render(80);
@@ -66,12 +59,13 @@ describe("AccountManager search/filter", () => {
 		expect(component.hasActiveSearch()).toBe(true);
 		const noMatch = component.render(80).join("\n");
 		expect(noMatch).toContain("No matching providers");
+		expect(noMatch).not.toContain("Anthropic");
+		expect(noMatch).not.toContain("Groq");
+		expect(noMatch).not.toContain("OpenAI");
 
-		// Backspace should pop one char and still be active
 		component.handleInput("\x7f");
 		expect(component.hasActiveSearch()).toBe(true);
 
-		// Esc clears
 		component.handleInput("\x1b");
 		expect(component.hasActiveSearch()).toBe(false);
 		expect(component.render(80).join("\n")).toContain("Type to search");
@@ -79,25 +73,32 @@ describe("AccountManager search/filter", () => {
 		component.dispose();
 	});
 
-	it("arrow navigation wraps filtered list", () => {
+	it("arrow navigation stays within filtered providers", () => {
 		const inventory = makeEmptyInventory();
 		const component = new AccountManagerComponent(inventory, makeCallbacks(), { terminalHeight: 40 });
 		component.render(80);
 		component.handleInput("\x1b[D");
-		// Filter to a small subset e.g. "open" matches openai, openai-codex, openrouter
 		for (const ch of "open") component.handleInput(ch);
 		expect(component.hasActiveSearch()).toBe(true);
 		const before = component.render(80).join("\n");
 		expect(before).toContain("Search: open");
+		expect(before).toContain("OpenAI");
+		expect(before).not.toContain("Anthropic");
 
-		// Arrow down should change active provider within filtered set
 		component.handleInput("\x1b[B");
+		let afterDown = component.render(80).join("\n");
+		expect(afterDown).toContain("Search: open");
+		expect(afterDown).not.toContain("Anthropic");
+		expect(afterDown).toContain("OpenAI");
+
 		component.handleInput("\x1b[B");
-		// Arrow up wraps
+		afterDown = component.render(80).join("\n");
+		expect(afterDown).not.toContain("Anthropic");
+
 		component.handleInput("\x1b[A");
-		// Should not throw and should still be filtered
-		expect(component.hasActiveSearch()).toBe(true);
-		expect(component.render(80).join("\n")).toContain("Search: open");
+		const afterUp = component.render(80).join("\n");
+		expect(afterUp).toContain("Search: open");
+		expect(afterUp).not.toContain("Anthropic");
 
 		component.dispose();
 	});

--- a/packages/coding-agent/src/modes/components/account-manager.ts
+++ b/packages/coding-agent/src/modes/components/account-manager.ts
@@ -351,25 +351,30 @@ export class AccountManagerComponent implements Component {
 			: selection.kind === "account" && selection.credentialId === target.credentialId;
 	}
 
+	/** Whether a query is active and Esc should clear it rather than close the card. */
 	hasActiveSearch(): boolean {
 		return this.#searchQuery.length > 0 && (this.#searchTypedByUser || this.#isSearchEnabled());
 	}
 
+	/** Whether the provider list overflows and filtering is useful. */
 	#isSearchEnabled(): boolean {
 		const baseline = this.#splitRowCount - SIDEBAR_SUMMARY_ROWS;
 		return this.#entries.length > Math.max(1, baseline);
 	}
 
+	/** Whether to render the Type to search / Search: row atop the sidebar. */
 	#shouldRenderSearchStatus(): boolean {
 		return this.#isSearchEnabled() || this.#searchQuery.length > 0;
 	}
 
+	/** Providers matching the current query, or all when the query is empty. */
 	get #filteredEntries(): AccountSidebarEntry[] {
 		const query = this.#searchQuery.trim();
 		if (!query) return this.#entries;
 		return fuzzyFilter(this.#entries, query, entry => `${entry.label} ${entry.providerId}`);
 	}
 
+	/** Update the query and keep the active provider visible within the filtered set. */
 	#setSearchQuery(query: string, typedByUser = false): void {
 		this.#searchQuery = query;
 		this.#searchTypedByUser = query.length > 0 && typedByUser;
@@ -383,6 +388,7 @@ export class AccountManagerComponent implements Component {
 		this.#sidebarScroll = 0;
 	}
 
+	/** Handle backspace and printable input for the sidebar filter. Returns true if consumed. */
 	#handleSearchInput(data: string): boolean {
 		if (matchesKey(data, "backspace") || matchesKey(data, "ctrl+h")) {
 			if (!this.hasActiveSearch()) return false;
@@ -400,6 +406,7 @@ export class AccountManagerComponent implements Component {
 		return true;
 	}
 
+	/** Render the Type to search / Search: status row. */
 	#renderSearchStatus(width: number): string {
 		const query = this.#searchQuery.trim();
 		const suffix = query ? `Search: ${this.#searchQuery}` : "Type to search";
@@ -689,6 +696,7 @@ export class AccountManagerComponent implements Component {
 
 		if (searchOffset === 1 && overSplit && contentLine === 0 && innerCol >= 0 && innerCol < this.#sidebarWidthLast) {
 			this.#focus = "sidebar";
+			this.#requestRender?.();
 			return true;
 		}
 		if (overSidebar) {

--- a/packages/coding-agent/src/modes/components/account-manager.ts
+++ b/packages/coding-agent/src/modes/components/account-manager.ts
@@ -23,6 +23,8 @@
 import { getOAuthProviders } from "@veyyon/ai/oauth";
 import {
 	type Component,
+	extractPrintableText,
+	fuzzyFilter,
 	HoverFade,
 	Input,
 	matchesKey,
@@ -233,6 +235,9 @@ export class AccountManagerComponent implements Component {
 	#bodyLines: BodyLine[] = [];
 	/** Mirrors `accounts.loadBalancing`; only `b` and the chip change it. */
 	#loadBalancing = false;
+	#searchQuery = "";
+	/** True while #searchQuery was typed by user; keeps query clearable after resize. */
+	#searchTypedByUser = false;
 
 	constructor(inventory: AccountInventory, callbacks: AccountManagerCallbacks, options: AccountManagerOptions = {}) {
 		this.#inventory = inventory;
@@ -303,6 +308,15 @@ export class AccountManagerComponent implements Component {
 			this.#activeProviderId = this.#entries[0]?.providerId ?? "";
 			this.#sidebarFollowActive = true;
 		}
+		if (this.#searchQuery.trim()) {
+			const filtered = this.#filteredEntries;
+			if (filtered.length > 0 && !filtered.some(entry => entry.providerId === this.#activeProviderId)) {
+				this.#activeProviderId = filtered[0]?.providerId ?? this.#activeProviderId;
+				this.#sidebarFollowActive = true;
+				this.#selectFirstEntry();
+			}
+			this.#sidebarScroll = 0;
+		}
 	}
 
 	#activeEntry(): AccountSidebarEntry | undefined {
@@ -337,6 +351,61 @@ export class AccountManagerComponent implements Component {
 			: selection.kind === "account" && selection.credentialId === target.credentialId;
 	}
 
+	hasActiveSearch(): boolean {
+		return this.#searchQuery.length > 0 && (this.#searchTypedByUser || this.#isSearchEnabled());
+	}
+
+	#isSearchEnabled(): boolean {
+		const baseline = this.#splitRowCount - SIDEBAR_SUMMARY_ROWS;
+		return this.#entries.length > Math.max(1, baseline);
+	}
+
+	#shouldRenderSearchStatus(): boolean {
+		return this.#isSearchEnabled() || this.#searchQuery.length > 0;
+	}
+
+	get #filteredEntries(): AccountSidebarEntry[] {
+		const query = this.#searchQuery.trim();
+		if (!query) return this.#entries;
+		return fuzzyFilter(this.#entries, query, entry => `${entry.label} ${entry.providerId}`);
+	}
+
+	#setSearchQuery(query: string, typedByUser = false): void {
+		this.#searchQuery = query;
+		this.#searchTypedByUser = query.length > 0 && typedByUser;
+		const filtered = this.#filteredEntries;
+		if (filtered.length > 0 && !filtered.some(entry => entry.providerId === this.#activeProviderId)) {
+			this.#activeProviderId = filtered[0]?.providerId ?? this.#activeProviderId;
+			this.#bodyScroll = 0;
+			this.#sidebarFollowActive = true;
+			this.#selectFirstEntry();
+		}
+		this.#sidebarScroll = 0;
+	}
+
+	#handleSearchInput(data: string): boolean {
+		if (matchesKey(data, "backspace") || matchesKey(data, "ctrl+h")) {
+			if (!this.hasActiveSearch()) return false;
+			const chars = [...this.#searchQuery];
+			chars.pop();
+			this.#setSearchQuery(chars.join(""), true);
+			return true;
+		}
+		if (this.#focus !== "sidebar" && !this.hasActiveSearch()) return false;
+		if (!this.#isSearchEnabled()) return false;
+		const printable = extractPrintableText(data);
+		if (printable === undefined) return false;
+		if (this.#searchQuery.length === 0 && printable.trim().length === 0) return false;
+		this.#setSearchQuery(this.#searchQuery + printable, true);
+		return true;
+	}
+
+	#renderSearchStatus(width: number): string {
+		const query = this.#searchQuery.trim();
+		const suffix = query ? `Search: ${this.#searchQuery}` : "Type to search";
+		return theme.fg("muted", truncateToWidth(`  ${suffix}`, width));
+	}
+
 	// ═══════════════════════════════════════════════════════════════════════
 	// Input
 	// ═══════════════════════════════════════════════════════════════════════
@@ -360,6 +429,10 @@ export class AccountManagerComponent implements Component {
 				this.#pendingLogoutCredentialId = null;
 				return;
 			}
+			if (this.hasActiveSearch()) {
+				this.#setSearchQuery("");
+				return;
+			}
 			this.#callbacks.onCancel();
 			return;
 		}
@@ -380,6 +453,7 @@ export class AccountManagerComponent implements Component {
 		// point every non-`x` key passes rather than inside each branch, so a key added later cannot
 		// forget to do it.
 		if (data !== "x") this.#pendingLogoutCredentialId = null;
+		if (this.#handleSearchInput(data)) return;
 
 		if (matchesSelectUp(data)) {
 			this.#step(-1);
@@ -455,13 +529,14 @@ export class AccountManagerComponent implements Component {
 	#step(direction: 1 | -1): void {
 		this.#pendingLogoutCredentialId = null;
 		if (this.#focus === "sidebar") {
-			if (this.#entries.length === 0) return;
+			const filtered = this.#filteredEntries;
+			if (filtered.length === 0) return;
 			const current = Math.max(
 				0,
-				this.#entries.findIndex(entry => entry.providerId === this.#activeProviderId),
+				filtered.findIndex(entry => entry.providerId === this.#activeProviderId),
 			);
-			const next = (current + direction + this.#entries.length) % this.#entries.length;
-			this.#selectProvider(this.#entries[next]?.providerId ?? this.#activeProviderId);
+			const next = (current + direction + filtered.length) % filtered.length;
+			this.#selectProvider(filtered[next]?.providerId ?? this.#activeProviderId);
 			return;
 		}
 		const rows = this.#rows();
@@ -572,23 +647,34 @@ export class AccountManagerComponent implements Component {
 		const innerCol = event.col - this.#frameLeft - 2;
 		const contentLine = event.row - this.#contentRowStart;
 		const overSplit = contentLine >= 0 && contentLine < this.#splitRowCount;
+		const searchOffset = this.#shouldRenderSearchStatus() ? 1 : 0;
 		// The summary block owns the last rows of the sidebar column and answers to no provider,
 		// so a click there must select nothing rather than index past the visible list.
 		const overSidebar =
-			overSplit && contentLine < this.#sidebarListRows() && innerCol >= 0 && innerCol < this.#sidebarWidthLast;
+			overSplit &&
+			contentLine >= searchOffset &&
+			contentLine < searchOffset + this.#sidebarListRows() &&
+			innerCol >= 0 &&
+			innerCol < this.#sidebarWidthLast;
 		const overBody = overSplit && innerCol >= this.#sidebarWidthLast + 3;
 
 		if (event.motion) {
-			this.#sidebarHover = overSidebar ? this.#sidebarScroll + contentLine : null;
+			this.#sidebarHover = overSidebar ? this.#sidebarScroll + contentLine - searchOffset : null;
 			this.#sidebarFade?.set(this.#sidebarHover);
 			return true;
 		}
 		if (event.wheel !== null) {
-			if (overSidebar) {
+			const overSidebarForWheel =
+				overSplit &&
+				contentLine < searchOffset + this.#sidebarListRows() &&
+				innerCol >= 0 &&
+				innerCol < this.#sidebarWidthLast;
+			if (overSidebarForWheel) {
+				const filtered = this.#filteredEntries;
 				this.#sidebarScroll = clampLow(
 					this.#sidebarScroll + event.wheel,
 					0,
-					Math.max(0, this.#entries.length - this.#sidebarListRows()),
+					Math.max(0, filtered.length - this.#sidebarListRows()),
 				);
 			} else if (overBody) {
 				this.#bodyScroll = clampLow(
@@ -601,8 +687,14 @@ export class AccountManagerComponent implements Component {
 		}
 		if (!event.leftClick) return true;
 
+		if (searchOffset === 1 && overSplit && contentLine === 0 && innerCol >= 0 && innerCol < this.#sidebarWidthLast) {
+			this.#focus = "sidebar";
+			return true;
+		}
 		if (overSidebar) {
-			const entry = this.#entries[this.#sidebarScroll + contentLine];
+			const filtered = this.#filteredEntries;
+			const providerLine = contentLine - searchOffset;
+			const entry = filtered[this.#sidebarScroll + providerLine];
 			if (entry) {
 				this.#focus = "sidebar";
 				this.#selectProvider(entry.providerId);
@@ -663,11 +755,12 @@ export class AccountManagerComponent implements Component {
 	 * the fold, and the wheel could never reach the last three providers.
 	 */
 	#sidebarListRows(): number {
-		return Math.max(1, this.#splitRowCount - SIDEBAR_SUMMARY_ROWS);
+		return Math.max(1, this.#splitRowCount - SIDEBAR_SUMMARY_ROWS - (this.#shouldRenderSearchStatus() ? 1 : 0));
 	}
 
 	#renderSidebar(width: number): string[] {
 		const listRows = this.#sidebarListRows();
+		const filtered = this.#filteredEntries;
 		// The scroll offset is the wheel's to pan freely; only an ACTIVATION snaps it back to the
 		// selected provider. Following the active entry on every frame instead made the wheel look
 		// broken: each pan was undone by the very next repaint, so the providers below the fold
@@ -675,40 +768,49 @@ export class AccountManagerComponent implements Component {
 		if (this.#sidebarFollowActive) {
 			const activeIndex = Math.max(
 				0,
-				this.#entries.findIndex(entry => entry.providerId === this.#activeProviderId),
+				filtered.findIndex(entry => entry.providerId === this.#activeProviderId),
 			);
 			if (activeIndex < this.#sidebarScroll) this.#sidebarScroll = activeIndex;
 			else if (activeIndex >= this.#sidebarScroll + listRows) this.#sidebarScroll = activeIndex - listRows + 1;
 			this.#sidebarFollowActive = false;
 		}
-		this.#sidebarScroll = clampLow(this.#sidebarScroll, 0, Math.max(0, this.#entries.length - listRows));
+		this.#sidebarScroll = clampLow(this.#sidebarScroll, 0, Math.max(0, filtered.length - listRows));
 
 		const lines: string[] = [];
-		for (let i = this.#sidebarScroll; i < Math.min(this.#entries.length, this.#sidebarScroll + listRows); i++) {
-			const entry = this.#entries[i];
-			if (!entry) continue;
-			const active = entry.providerId === this.#activeProviderId;
-			const cursor = active && this.#focus === "sidebar" ? theme.fg("accent", theme.nav.cursor) : " ";
-			// A provider you hold no account for dims ENTIRELY, label included. Only its count was
-			// dimmed before, so forty empty providers sat at the same text weight as the three you use
-			// and the eye had to read the right-hand column to find them. The list's job is "what you
-			// have, then what you could have", and weight is what says which is which.
-			const label = active
-				? theme.bold(theme.fg("accent", entry.label))
-				: entry.accountCount === 0
-					? theme.fg("dim", entry.label)
-					: entry.label;
-			const annotation = entry.hasFailure
-				? `${theme.fg("dim", entry.annotation)} ${theme.fg("warning", theme.status.warning)}`
-				: `${theme.fg("dim", entry.annotation)}  `;
-			const left = `${cursor} ${label}`;
-			const gap = Math.max(1, width - visibleWidth(left) - visibleWidth(annotation));
-			let line = `${left}${" ".repeat(gap)}${annotation}`;
-			const hoverStrength = this.#sidebarStrength(i);
-			if (hoverStrength > 0) line = hoverBandAt(line, width, hoverStrength);
-			lines.push(line);
+		if (this.#shouldRenderSearchStatus()) {
+			lines.push(this.#renderSearchStatus(width));
 		}
-		while (lines.length < listRows + 1) lines.push("");
+		if (filtered.length === 0) {
+			lines.push(theme.fg("muted", truncateToWidth("  No matching providers", width)));
+			while (lines.length < (this.#shouldRenderSearchStatus() ? 1 : 0) + listRows) lines.push("");
+		} else {
+			for (let i = this.#sidebarScroll; i < Math.min(filtered.length, this.#sidebarScroll + listRows); i++) {
+				const entry = filtered[i];
+				if (!entry) continue;
+				const active = entry.providerId === this.#activeProviderId;
+				const cursor = active && this.#focus === "sidebar" ? theme.fg("accent", theme.nav.cursor) : " ";
+				// A provider you hold no account for dims ENTIRELY, label included. Only its count was
+				// dimmed before, so forty empty providers sat at the same text weight as the three you use
+				// and the eye had to read the right-hand column to find them. The list's job is "what you
+				// have, then what you could have", and weight is what says which is which.
+				const label = active
+					? theme.bold(theme.fg("accent", entry.label))
+					: entry.accountCount === 0
+						? theme.fg("dim", entry.label)
+						: entry.label;
+				const annotation = entry.hasFailure
+					? `${theme.fg("dim", entry.annotation)} ${theme.fg("warning", theme.status.warning)}`
+					: `${theme.fg("dim", entry.annotation)}  `;
+				const left = `${cursor} ${label}`;
+				const gap = Math.max(1, width - visibleWidth(left) - visibleWidth(annotation));
+				let line = `${left}${" ".repeat(gap)}${annotation}`;
+				const hoverStrength = this.#sidebarStrength(i);
+				if (hoverStrength > 0) line = hoverBandAt(line, width, hoverStrength);
+				lines.push(line);
+			}
+			while (lines.length < (this.#shouldRenderSearchStatus() ? 1 : 0) + listRows) lines.push("");
+		}
+		while (lines.length < (this.#shouldRenderSearchStatus() ? 1 : 0) + listRows + 1) lines.push("");
 		lines.push(theme.fg("borderAccent", "─".repeat(Math.max(1, width - 2))));
 		lines.push(theme.fg("dim", truncateToWidth(sidebarSummaryLine(this.#inventory), width)));
 		return lines;


### PR DESCRIPTION
Refs #885

### Summary
Selecting a provider in `/providers` required scrolling 60+ entries. Adds interactive filter at top of the account manager sidebar — `fuzzyFilter` across `label + id` (real-time prefix/fuzzy), `↑↓` on filtered, `Enter` confirm, `Backspace`/`Esc` clear. Sidebar must be focused (`←` or click) then type; `Esc` clears filter before close.

### Changes
- `account-manager.ts`: `Type to search` / `Search: q` row, `hasActiveSearch` ladder, `filteredEntries` via `fuzzyFilter`, sidebar render/wheel/click respect filtered, `No matching providers` empty state
- `account-manager-search.test.ts`: contract tests for filter, empty, `Esc`/`Backspace`, `↑↓` wrap on filtered
- `CHANGELOG.md`: `### Added` Refs #885

### Testing
- `bun --cwd=packages/coding-agent src/modes/components/account-manager-search-smoke.ts` → `ALL SMOKE PASS`
- `bun run dev` → `/providers` manual on Windows `120×40`: `←` → `anth` → Anthropic only, `zzz` → empty, `Esc` clears (screenshots below)
- `biome check` / `tsgo -p tsconfig.tools.json` / `tsgo -p packages/coding-agent/tsconfig.json` → `exit:0`

### Screenshots
**Before (main — no search)**
![Before](https://github.com/user-attachments/assets/6e589a7c-7e63-4502-86e4-67c65e074c62)

**After — `Search: Anthropic` (branch)**
![After - Anthropic](https://github.com/user-attachments/assets/4288756a-1eb6-442f-9aee-44b62826c21d)

**After — `Search: ZZZZ` empty (branch)**
![After - empty](https://github.com/user-attachments/assets/8d008287-8dbd-45cd-b997-0eb0ed81c1a6)

### Checklist
- [x] Changelog `Refs #885`
- [x] `biome check` + `tsgo` pass
- [x] Tests added (full-suite safe, no `mock.module`)
- [x] Handbook `no update` — `features/connectors.md` is high-level, no detailed card page
- [x] No `Closes`, no AI trailer, staged paths only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive search to the `/providers` sidebar.
  - Search provides real-time fuzzy matching by provider name and ID.
  - Added keyboard navigation, including arrow-key movement through filtered results.
  - Added Backspace and Escape shortcuts to clear searches.
  - Displays a clear message when no providers match.

- **Bug Fixes**
  - Updated selection, scrolling, clicking, and navigation to work correctly with filtered results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->