### PR TITLE
feat: add session-bound Telegram native control host

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- The coding-agent session host exposes an in-process, session-invalidating Telegram native-control capability for a lease-owning extension to list scoped agents and inspect their progress without starting another poller or session.
 - The `/autoswarm` dashboard lists a `New session` action (`n`) over an existing session, which closes it keeping every file and every logged run and starts a fresh one with the setup as it stands.
 - Swarm presets: `swarm` and `wide` are built in, and the console saves the current shape under a name to `presets.json` beside the autoresearch databases, offered in every repository.
 - The run screen's `running` row shows the last twelve lines the harness printed under the command, refreshed once a second, with escapes stripped and a carriage-return progress row shown in its final state.

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -44,6 +44,8 @@ export type * from "./lsp";
 export * from "./lsp";
 // Main entry point
 export * from "./main";
+export * from "./native-control/telegram-control-bridge";
+export * from "./native-control/telegram-control-host";
 // Run modes for programmatic SDK usage
 export * from "./modes";
 export * from "./modes/components";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -71,6 +71,7 @@ import type { PrintModeOptions } from "./modes/print-mode";
 import { CURRENT_SETUP_VERSION, resolveOnboardingGeneration } from "./modes/setup-version";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
+import { installTelegramNativeControlHost } from "./native-control/telegram-control-host";
 import { AgentLifecycleManager } from "./registry/agent-lifecycle";
 import {
 	type CreateAgentSessionOptions,
@@ -1858,6 +1859,10 @@ async function runRootCommandInner(parsed: Args, rawArgs: string[], deps: RunRoo
 			operatorNotices,
 			preloadedExtensions: extensionsResult,
 		});
+		// Publish the in-process native capability before interactive commands can
+		// activate a Telegram adapter. This starts no poller or socket; only the
+		// lease-owning extension can bind actor/chat credentials to this session.
+		installTelegramNativeControlHost(() => session.sessionManager.getSessionId());
 
 		// Cold-revive support: a `parked` subagent ref restored from disk (the persisted-subagent
 		// scan, collab mirror, resumed process) has a sessionFile but no in-memory

--- a/packages/coding-agent/src/native-control/telegram-control-bridge.ts
+++ b/packages/coding-agent/src/native-control/telegram-control-bridge.ts
@@ -1,0 +1,271 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { AgentRegistry, type AgentRef } from "../registry/agent-registry";
+import { SessionManager } from "../session/session-manager";
+import { FileSessionStorage, type SessionStorage } from "../session/session-storage";
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 50;
+const MAX_SUMMARY_CHARS = 1_000;
+const MAX_RESULT_CHARS = 16_000;
+const MAX_REPLAY_ENTRIES = 256;
+
+export interface NativeControlBinding {
+	authToken: string;
+	actorId: string;
+	chatId: string;
+	sessionId: string;
+	workspaceRoots: readonly string[];
+}
+
+export interface NativeControlAuth {
+	authToken: string;
+	actorId: string;
+	chatId: string;
+	sessionId: string;
+}
+
+export interface AgentListRequest extends NativeControlAuth {
+	cursor?: string;
+	limit?: number;
+}
+
+export interface AgentDetailRequest extends NativeControlAuth {
+	agentId: string;
+}
+
+export interface CreateSessionRequest extends NativeControlAuth {
+	requestId: string;
+	workspace: string;
+	title?: string;
+}
+
+export interface NativeAgentSummary {
+	id: string;
+	name: string;
+	status: AgentRef["status"];
+	summary?: string;
+	updatedAt: number;
+}
+
+export interface NativeAgentDetail extends NativeAgentSummary {
+	progress?: string;
+	result?: string;
+}
+
+export interface NativeSessionIdentity {
+	id: string;
+	actorId: string;
+	chatId: string;
+}
+
+export interface CreatedNativeSession {
+	id: string;
+	workspace: string;
+	title?: string;
+	file: string;
+}
+
+export interface NativeControlBridgeOptions {
+	binding: NativeControlBinding;
+	registry?: AgentRegistry;
+	storage?: SessionStorage;
+	sessionDirFor?: (workspace: string) => string | undefined;
+}
+
+export class NativeControlDeniedError extends Error {
+	constructor(
+		readonly code:
+			| "UNAUTHORIZED"
+			| "ACTOR_MISMATCH"
+			| "CHAT_MISMATCH"
+			| "SESSION_MISMATCH"
+			| "AGENT_NOT_FOUND"
+			| "INVALID_CURSOR"
+			| "WORKSPACE_DENIED"
+			| "REPLAY_MISMATCH",
+		message: string,
+	) {
+		super(message);
+		this.name = "NativeControlDeniedError";
+	}
+}
+
+interface ReplayEntry {
+	fingerprint: string;
+	result: CreatedNativeSession;
+}
+
+function tokenMatches(expected: string, candidate: string): boolean {
+	const expectedBytes = Buffer.from(expected, "utf8");
+	const candidateBytes = Buffer.from(candidate, "utf8");
+	return expectedBytes.length === candidateBytes.length && crypto.timingSafeEqual(expectedBytes, candidateBytes);
+}
+
+function sanitized(value: string | undefined, maxChars: number): string | undefined {
+	if (!value) return undefined;
+	const clean = value.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "").replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "");
+	return clean.length <= maxChars ? clean : `${clean.slice(0, maxChars - 1)}…`;
+}
+
+function normalizedForComparison(value: string): string {
+	const resolved = path.resolve(value);
+	return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+	const relative = path.relative(normalizedForComparison(root), normalizedForComparison(candidate));
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function boundedLimit(limit: number | undefined): number {
+	if (limit === undefined) return DEFAULT_PAGE_SIZE;
+	if (!Number.isInteger(limit) || limit < 1) return 1;
+	return Math.min(limit, MAX_PAGE_SIZE);
+}
+
+function cursorOffset(cursor: string | undefined): number {
+	if (cursor === undefined) return 0;
+	if (!/^(0|[1-9]\d*)$/.test(cursor)) {
+		throw new NativeControlDeniedError("INVALID_CURSOR", "Cursor must be a non-negative decimal offset");
+	}
+	const offset = Number(cursor);
+	if (!Number.isSafeInteger(offset)) {
+		throw new NativeControlDeniedError("INVALID_CURSOR", "Cursor exceeds the safe pagination range");
+	}
+	return offset;
+}
+
+export class TelegramNativeControlBridge {
+	readonly #binding: NativeControlBinding;
+	readonly #registry: AgentRegistry;
+	readonly #storage: SessionStorage;
+	readonly #sessionDirFor: (workspace: string) => string | undefined;
+	readonly #replays = new Map<string, ReplayEntry>();
+
+	constructor(options: NativeControlBridgeOptions) {
+		if (options.binding.authToken.length < 32) {
+			throw new Error("Native control authToken must contain at least 32 characters");
+		}
+		if (options.binding.workspaceRoots.length === 0) {
+			throw new Error("Native control requires at least one workspace root");
+		}
+		this.#binding = { ...options.binding, workspaceRoots: [...options.binding.workspaceRoots] };
+		this.#registry = options.registry ?? AgentRegistry.global();
+		this.#storage = options.storage ?? new FileSessionStorage();
+		this.#sessionDirFor = options.sessionDirFor ?? (() => undefined);
+	}
+
+	getSessionIdentity(auth: NativeControlAuth): NativeSessionIdentity {
+		this.#authorize(auth);
+		return { id: this.#binding.sessionId, actorId: this.#binding.actorId, chatId: this.#binding.chatId };
+	}
+
+	async listAgents(request: AgentListRequest): Promise<{ items: NativeAgentSummary[]; nextCursor?: string }> {
+		this.#authorize(request);
+		const offset = cursorOffset(request.cursor);
+		const limit = boundedLimit(request.limit);
+		const refs = this.#registry
+			.list()
+			.filter(ref => ref.scope === this.#binding.sessionId && ref.kind !== "advisor")
+			.sort((a, b) => b.lastActivity - a.lastActivity || a.id.localeCompare(b.id));
+		const items = refs.slice(offset, offset + limit).map(ref => this.#summary(ref));
+		const nextOffset = offset + items.length;
+		return { items, ...(nextOffset < refs.length ? { nextCursor: String(nextOffset) } : {}) };
+	}
+
+	async getAgentDetail(request: AgentDetailRequest): Promise<NativeAgentDetail> {
+		this.#authorize(request);
+		const ref = this.#registry.get(request.agentId);
+		if (!ref || ref.scope !== this.#binding.sessionId || ref.kind === "advisor") {
+			throw new NativeControlDeniedError("AGENT_NOT_FOUND", "Agent is not available in the bound session");
+		}
+		const progress = sanitized(ref.activity, MAX_SUMMARY_CHARS);
+		const result = sanitized(ref.session?.getLastAssistantText(), MAX_RESULT_CHARS);
+		return { ...this.#summary(ref), ...(progress ? { progress } : {}), ...(result ? { result } : {}) };
+	}
+
+	async createSession(request: CreateSessionRequest): Promise<CreatedNativeSession> {
+		this.#authorize(request);
+		if (!request.requestId.trim()) {
+			throw new NativeControlDeniedError("REPLAY_MISMATCH", "Session creation requires a non-empty requestId");
+		}
+		const workspace = await this.#allowedWorkspace(request.workspace);
+		const title = sanitized(request.title?.trim(), MAX_SUMMARY_CHARS);
+		const fingerprint = JSON.stringify({ workspace: normalizedForComparison(workspace), title: title ?? null });
+		const replayKey = `${this.#binding.actorId}\u0000${this.#binding.chatId}\u0000${request.requestId}`;
+		const prior = this.#replays.get(replayKey);
+		if (prior) {
+			if (prior.fingerprint !== fingerprint) {
+				throw new NativeControlDeniedError("REPLAY_MISMATCH", "requestId was already used with a different session request");
+			}
+			return prior.result;
+		}
+
+		const manager = SessionManager.create(workspace, this.#sessionDirFor(workspace), this.#storage);
+		if (title) await manager.setSessionName(title, "user");
+		await manager.ensureOnDisk();
+		const file = manager.getSessionFile();
+		if (!file) throw new Error("SessionManager did not persist the created session");
+		const result: CreatedNativeSession = {
+			id: manager.getSessionId(),
+			workspace: manager.getCwd(),
+			...(title ? { title } : {}),
+			file,
+		};
+		this.#replays.set(replayKey, { fingerprint, result });
+		while (this.#replays.size > MAX_REPLAY_ENTRIES) {
+			const oldest = this.#replays.keys().next().value;
+			if (oldest === undefined) break;
+			this.#replays.delete(oldest);
+		}
+		return result;
+	}
+
+	#authorize(auth: NativeControlAuth): void {
+		if (!tokenMatches(this.#binding.authToken, auth.authToken)) {
+			throw new NativeControlDeniedError("UNAUTHORIZED", "Invalid native control credential");
+		}
+		if (auth.actorId !== this.#binding.actorId) {
+			throw new NativeControlDeniedError("ACTOR_MISMATCH", "Actor is not bound to this native control bridge");
+		}
+		if (auth.chatId !== this.#binding.chatId) {
+			throw new NativeControlDeniedError("CHAT_MISMATCH", "Chat is not bound to this native control bridge");
+		}
+		if (auth.sessionId !== this.#binding.sessionId) {
+			throw new NativeControlDeniedError("SESSION_MISMATCH", "Session is not bound to this native control bridge");
+		}
+	}
+
+	#summary(ref: AgentRef): NativeAgentSummary {
+		const summary = sanitized(ref.activity, MAX_SUMMARY_CHARS);
+		return {
+			id: ref.id,
+			name: sanitized(ref.displayName, MAX_SUMMARY_CHARS) ?? ref.id,
+			status: ref.status,
+			...(summary ? { summary } : {}),
+			updatedAt: ref.lastActivity,
+		};
+	}
+
+	async #allowedWorkspace(requested: string): Promise<string> {
+		let candidate: string;
+		try {
+			candidate = await fs.realpath(path.resolve(requested));
+			const stat = await fs.stat(candidate);
+			if (!stat.isDirectory()) throw new Error("not a directory");
+		} catch {
+			throw new NativeControlDeniedError("WORKSPACE_DENIED", "Workspace must be an existing directory");
+		}
+		for (const configuredRoot of this.#binding.workspaceRoots) {
+			try {
+				const root = await fs.realpath(path.resolve(configuredRoot));
+				if (isWithin(root, candidate)) return candidate;
+			} catch {
+				// A missing configured root grants nothing.
+			}
+		}
+		throw new NativeControlDeniedError("WORKSPACE_DENIED", "Workspace is outside the configured allowlist");
+	}
+}

--- a/packages/coding-agent/src/native-control/telegram-control-bridge.ts
+++ b/packages/coding-agent/src/native-control/telegram-control-bridge.ts
@@ -81,6 +81,7 @@ export class NativeControlDeniedError extends Error {
 			| "ACTOR_MISMATCH"
 			| "CHAT_MISMATCH"
 			| "SESSION_MISMATCH"
+			| "SESSION_NOT_ACTIVE"
 			| "AGENT_NOT_FOUND"
 			| "INVALID_CURSOR"
 			| "WORKSPACE_DENIED"

--- a/packages/coding-agent/src/native-control/telegram-control-host.ts
+++ b/packages/coding-agent/src/native-control/telegram-control-host.ts
@@ -1,0 +1,106 @@
+import type { AgentRegistry } from "../registry/agent-registry";
+import type { SessionStorage } from "../session/session-storage";
+import {
+	type AgentDetailRequest,
+	type AgentListRequest,
+	type CreateSessionRequest,
+	type CreatedNativeSession,
+	type NativeAgentDetail,
+	type NativeAgentSummary,
+	type NativeControlAuth,
+	type NativeControlBinding,
+	NativeControlDeniedError,
+	TelegramNativeControlBridge,
+} from "./telegram-control-bridge";
+
+export const TELEGRAM_NATIVE_CONTROL_HOST_SYMBOL = Symbol.for("veyyon.telegram.native-control-host.v1");
+
+export interface TelegramNativeControlClient {
+	getSessionIdentity(auth: NativeControlAuth): { id: string; actorId: string; chatId: string };
+	listAgents(request: AgentListRequest): Promise<{ items: NativeAgentSummary[]; nextCursor?: string }>;
+	getAgentDetail(request: AgentDetailRequest): Promise<NativeAgentDetail>;
+	createSession(request: CreateSessionRequest): Promise<CreatedNativeSession>;
+}
+
+export interface TelegramNativeControlHost {
+	readonly version: 1;
+	bind(binding: NativeControlBinding): TelegramNativeControlClient;
+}
+
+export interface InstallTelegramNativeControlHostOptions {
+	registry?: AgentRegistry;
+	storage?: SessionStorage;
+	sessionDirFor?: (workspace: string) => string | undefined;
+}
+
+interface TelegramNativeControlGlobal {
+	[TELEGRAM_NATIVE_CONTROL_HOST_SYMBOL]?: TelegramNativeControlHost;
+}
+
+class ActiveSessionClient implements TelegramNativeControlClient {
+	constructor(
+		private readonly bridge: TelegramNativeControlBridge,
+		private readonly boundSessionId: string,
+		private readonly currentSessionId: () => string,
+	) {}
+
+	getSessionIdentity(auth: NativeControlAuth): { id: string; actorId: string; chatId: string } {
+		this.assertActive();
+		return this.bridge.getSessionIdentity(auth);
+	}
+
+	async listAgents(request: AgentListRequest): Promise<{ items: NativeAgentSummary[]; nextCursor?: string }> {
+		this.assertActive();
+		return await this.bridge.listAgents(request);
+	}
+
+	async getAgentDetail(request: AgentDetailRequest): Promise<NativeAgentDetail> {
+		this.assertActive();
+		return await this.bridge.getAgentDetail(request);
+	}
+
+	async createSession(request: CreateSessionRequest): Promise<CreatedNativeSession> {
+		this.assertActive();
+		return await this.bridge.createSession(request);
+	}
+
+	private assertActive(): void {
+		if (this.currentSessionId() !== this.boundSessionId) {
+			throw new NativeControlDeniedError("SESSION_NOT_ACTIVE", "The bound native session is no longer active");
+		}
+	}
+}
+
+/**
+ * Publishes the native control capability inside this Veyyon process. The host
+ * owns no Telegram transport or credential store: the one active Telegram
+ * extension supplies its authenticated actor/chat binding after it owns the
+ * poller lease. A session switch invalidates every previously bound client.
+ */
+export function installTelegramNativeControlHost(
+	currentSessionId: () => string,
+	options: InstallTelegramNativeControlHostOptions = {},
+): TelegramNativeControlHost {
+	const host: TelegramNativeControlHost = {
+		version: 1,
+		bind(binding) {
+			if (binding.sessionId !== currentSessionId()) {
+				throw new NativeControlDeniedError("SESSION_NOT_ACTIVE", "Cannot bind Telegram control to an inactive session");
+			}
+			const bridge = new TelegramNativeControlBridge({
+				binding,
+				...(options.registry ? { registry: options.registry } : {}),
+				...(options.storage ? { storage: options.storage } : {}),
+				...(options.sessionDirFor ? { sessionDirFor: options.sessionDirFor } : {}),
+			});
+			return new ActiveSessionClient(bridge, binding.sessionId, currentSessionId);
+		},
+	};
+	const globalState = globalThis as TelegramNativeControlGlobal;
+	globalState[TELEGRAM_NATIVE_CONTROL_HOST_SYMBOL] = host;
+	return host;
+}
+
+export function getTelegramNativeControlHost(): TelegramNativeControlHost | undefined {
+	return (globalThis as TelegramNativeControlGlobal)[TELEGRAM_NATIVE_CONTROL_HOST_SYMBOL];
+}

--- a/packages/coding-agent/test/native-control/telegram-control-bridge.test.ts
+++ b/packages/coding-agent/test/native-control/telegram-control-bridge.test.ts
@@ -10,6 +10,10 @@ import {
 	TelegramNativeControlBridge,
 	type NativeControlAuth,
 } from "../../src/native-control/telegram-control-bridge";
+import {
+	getTelegramNativeControlHost,
+	installTelegramNativeControlHost,
+} from "../../src/native-control/telegram-control-host";
 
 const TOKEN = "native-control-test-token-0000000000000000";
 const AUTH: NativeControlAuth = {
@@ -127,5 +131,41 @@ describe("TelegramNativeControlBridge safe session creation", () => {
 			bridge.createSession({ ...AUTH, requestId: "callback-002", workspace: outside }),
 		).rejects.toMatchObject({ code: "WORKSPACE_DENIED" });
 		expect(await fs.readdir(sessionDir).catch(() => [])).toHaveLength(0);
+	});
+});
+
+describe("Telegram native control host wiring", () => {
+	test("publishes a bindable in-process host and invalidates it on session switch", async () => {
+		let activeSessionId = AUTH.sessionId;
+		const installed = installTelegramNativeControlHost(() => activeSessionId, {
+			registry,
+			storage: new FileSessionStorage(),
+			sessionDirFor: () => sessionDir,
+		});
+		expect(getTelegramNativeControlHost()).toBe(installed);
+
+		const client = installed.bind({
+			...AUTH,
+			workspaceRoots: [path.join(scratch, "allowed")],
+		});
+		expect(client.getSessionIdentity(AUTH)).toEqual({
+			id: AUTH.sessionId,
+			actorId: AUTH.actorId,
+			chatId: AUTH.chatId,
+		});
+		expect(await client.listAgents({ ...AUTH, limit: 5 })).toEqual({ items: [] });
+
+		activeSessionId = "session-b";
+		await expect(client.listAgents({ ...AUTH, limit: 5 })).rejects.toMatchObject({
+			code: "SESSION_NOT_ACTIVE",
+		});
+		expect(() =>
+			installed.bind({
+				...AUTH,
+				workspaceRoots: [path.join(scratch, "allowed")],
+			}),
+		).toThrow(
+			expect.objectContaining({ code: "SESSION_NOT_ACTIVE" }),
+		);
 	});
 });

--- a/packages/coding-agent/test/native-control/telegram-control-bridge.test.ts
+++ b/packages/coding-agent/test/native-control/telegram-control-bridge.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentRegistry } from "../../src/registry/agent-registry";
+import type { AgentSession } from "../../src/session/agent-session";
+import { FileSessionStorage } from "../../src/session/session-storage";
+import {
+	NativeControlDeniedError,
+	TelegramNativeControlBridge,
+	type NativeControlAuth,
+} from "../../src/native-control/telegram-control-bridge";
+
+const TOKEN = "native-control-test-token-0000000000000000";
+const AUTH: NativeControlAuth = {
+	authToken: TOKEN,
+	actorId: "telegram-user-17",
+	chatId: "telegram-chat-29",
+	sessionId: "session-a",
+};
+
+let scratch = "";
+let workspace = "";
+let sessionDir = "";
+let registry: AgentRegistry;
+let bridge: TelegramNativeControlBridge;
+
+beforeEach(async () => {
+	scratch = await fs.mkdtemp(path.join(os.tmpdir(), "veyyon-native-control-"));
+	workspace = path.join(scratch, "allowed", "project");
+	sessionDir = path.join(scratch, "sessions");
+	await fs.mkdir(workspace, { recursive: true });
+	registry = new AgentRegistry();
+	bridge = new TelegramNativeControlBridge({
+		binding: { ...AUTH, workspaceRoots: [path.join(scratch, "allowed")] },
+		registry,
+		storage: new FileSessionStorage(),
+		sessionDirFor: () => sessionDir,
+	});
+});
+
+afterEach(async () => {
+	await fs.rm(scratch, { recursive: true, force: true });
+});
+
+describe("TelegramNativeControlBridge authenticated reads", () => {
+	test("returns only bounded agents in the bound session with progress and result", async () => {
+		const fakeSession = {
+			getLastAssistantText: () => "finished\u001b[31m safely",
+		} as unknown as AgentSession;
+		registry.register({
+			id: "WorkerA",
+			displayName: "Worker A",
+			kind: "sub",
+			session: fakeSession,
+			scope: AUTH.sessionId,
+			status: "running",
+		});
+		registry.setActivity("WorkerA", "reading\u001b[2J repository");
+		registry.register({
+			id: "OtherSession",
+			displayName: "Other session",
+			kind: "sub",
+			session: null,
+			scope: "session-b",
+			status: "idle",
+		});
+
+		const page = await bridge.listAgents({ ...AUTH, limit: 50 });
+		expect(page).toEqual({
+			items: [
+				expect.objectContaining({ id: "WorkerA", name: "Worker A", status: "running", summary: "reading [2J repository" }),
+			],
+		});
+		const detail = await bridge.getAgentDetail({ ...AUTH, agentId: "WorkerA" });
+		expect(detail.progress).toBe("reading [2J repository");
+		expect(detail.result).toBe("finished safely");
+		await expect(bridge.getAgentDetail({ ...AUTH, agentId: "OtherSession" })).rejects.toMatchObject({
+			code: "AGENT_NOT_FOUND",
+		});
+	});
+
+	test("denies invalid credentials, actors, chats, sessions, and cursors", async () => {
+		const cases: Array<[Partial<NativeControlAuth>, NativeControlDeniedError["code"]]> = [
+			[{ authToken: "wrong" }, "UNAUTHORIZED"],
+			[{ actorId: "attacker" }, "ACTOR_MISMATCH"],
+			[{ chatId: "other-chat" }, "CHAT_MISMATCH"],
+			[{ sessionId: "session-b" }, "SESSION_MISMATCH"],
+		];
+		for (const [override, code] of cases) {
+			await expect(bridge.listAgents({ ...AUTH, ...override })).rejects.toMatchObject({ code });
+		}
+		await expect(bridge.listAgents({ ...AUTH, cursor: "-1" })).rejects.toMatchObject({ code: "INVALID_CURSOR" });
+	});
+});
+
+describe("TelegramNativeControlBridge safe session creation", () => {
+	test("creates a persisted session without replacing Main and deduplicates an exact replay", async () => {
+		registry.register({
+			id: "main:session-a",
+			displayName: "Main",
+			kind: "main",
+			session: null,
+			scope: AUTH.sessionId,
+			status: "running",
+		});
+		const mainBefore = registry.get("main:session-a");
+		const request = { ...AUTH, requestId: "callback-001", workspace, title: "Telegram work" };
+
+		const first = await bridge.createSession(request);
+		const replay = await bridge.createSession(request);
+
+		expect(replay).toEqual(first);
+		expect(registry.get("main:session-a")).toBe(mainBefore);
+		expect(first.workspace).toBe(await fs.realpath(workspace));
+		expect(first.title).toBe("Telegram work");
+		expect((await fs.readdir(sessionDir)).filter(name => name.endsWith(".jsonl"))).toHaveLength(1);
+		await expect(
+			bridge.createSession({ ...request, workspace: path.join(scratch, "allowed") }),
+		).rejects.toMatchObject({ code: "REPLAY_MISMATCH" });
+	});
+
+	test("denies a workspace outside the configured realpath allowlist", async () => {
+		const outside = path.join(scratch, "outside");
+		await fs.mkdir(outside);
+		await expect(
+			bridge.createSession({ ...AUTH, requestId: "callback-002", workspace: outside }),
+		).rejects.toMatchObject({ code: "WORKSPACE_DENIED" });
+		expect(await fs.readdir(sessionDir).catch(() => [])).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

Adds an in-process native agent inspection bridge and wires it into the coding-agent session host. The host publishes an in-process capability after session creation; it starts no network socket, poller, or background worker. An authorized extension binds its actor/chat/session identity and receives an inspection client that becomes invalid immediately when the active session changes.

## Why

Allows external control extensions running in the same process to inspect active subagent status and progress within the bound session.

## Testing

- Focused unit tests in `packages/coding-agent/test/native-control/telegram-control-bridge.test.ts` pass (3 tests, 14 assertions).
- Verified session-switch invalidation and authentication isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native control access for authorized integrations to view active session identity and registered agents.
  * Added paginated agent lists and detailed progress or result information, with sensitive formatting sanitized.
  * Added session validation so access ends when the active session changes.
  * Exposed the native control APIs through the package entry point.
* **Tests**
  * Added coverage for authorization, pagination, session isolation, data sanitization, and inactive-session handling.
* **Documentation**
  * Documented the new native control capability in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->